### PR TITLE
fix(hosted-link): sanitize access_token/result from event payloads (#48)

### DIFF
--- a/src/routers/link_sessions.py
+++ b/src/routers/link_sessions.py
@@ -165,11 +165,48 @@ def _create_ephemeral_link_session(
     }
 
 
+# Keys that must never appear in hosted-link event payloads delivered to
+# browser or mobile webview clients. Hosted Link's completion contract is
+# public_token + metadata only; durable credentials (access_token, raw
+# extracted data, passwords) stay server-side and are exchanged by the
+# developer's backend via authenticated APIs.
+_HOSTED_EVENT_FORBIDDEN_KEYS = frozenset(
+    {
+        "access_token",
+        "accessToken",
+        "password",
+        "password_encrypted",
+        "username_encrypted",
+        "private_key",
+        "secret",
+        "result",
+        "data",
+    }
+)
+
+
+def _sanitize_hosted_event_data(data: Any) -> Any:
+    """Recursively strip forbidden keys from hosted-link event payloads.
+
+    Defense-in-depth so a future caller cannot accidentally leak
+    access_token or extracted result data to browser/webview clients.
+    """
+    if isinstance(data, dict):
+        return {
+            key: _sanitize_hosted_event_data(value)
+            for key, value in data.items()
+            if key not in _HOSTED_EVENT_FORBIDDEN_KEYS
+        }
+    if isinstance(data, list):
+        return [_sanitize_hosted_event_data(item) for item in data]
+    return data
+
+
 def _build_link_session_event(event_name: str, data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     return {
         "event": event_name,
         "timestamp": datetime.now(timezone.utc).isoformat(),
-        "data": data or {},
+        "data": _sanitize_hosted_event_data(data or {}),
     }
 
 
@@ -568,7 +605,9 @@ async def post_link_session_event(
 
     body = await request.json()
     event_name = body.get("event", "UNKNOWN")
-    data = {k: v for k, v in body.items() if k not in {"event", "access_token"}}
+    data = _sanitize_hosted_event_data(
+        {k: v for k, v in body.items() if k != "event"}
+    )
     updates = {}
     if event_name == "INSTITUTION_SELECTED":
         updates["status"] = "awaiting_credentials"

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -232,3 +232,73 @@ class TestUserIsolation:
             headers=second_user_headers,
         )
         assert response.status_code == 401
+
+
+class TestHostedLinkEventSanitization:
+    """Ensure hosted-link events never leak access_token / result payloads.
+
+    Enforces the completion contract: /link surfaces only public_token +
+    metadata to browser/mobile clients.
+    """
+
+    def test_build_event_strips_forbidden_keys(self):
+        from src.routers.link_sessions import _build_link_session_event
+
+        event = _build_link_session_event(
+            "CONNECTED",
+            data={
+                "public_token": "public-abc",
+                "access_token": "at-should-not-leak",
+                "result": {"balance": 1234, "access_token": "nested-leak"},
+                "site": "internal_bank",
+                "job_id": "job-1",
+            },
+        )
+
+        assert event["event"] == "CONNECTED"
+        assert event["data"]["public_token"] == "public-abc"
+        assert event["data"]["site"] == "internal_bank"
+        assert event["data"]["job_id"] == "job-1"
+        assert "access_token" not in event["data"]
+        assert "result" not in event["data"]
+
+    def test_sanitizer_handles_nested_lists(self):
+        from src.routers.link_sessions import _sanitize_hosted_event_data
+
+        sanitized = _sanitize_hosted_event_data(
+            {
+                "items": [
+                    {"name": "a", "access_token": "leak-a"},
+                    {"name": "b", "password": "pw"},
+                ],
+                "public_token": "public-xyz",
+            }
+        )
+
+        assert sanitized["public_token"] == "public-xyz"
+        assert sanitized["items"][0] == {"name": "a"}
+        assert sanitized["items"][1] == {"name": "b"}
+
+    def test_event_endpoint_strips_forbidden_keys(self, client, auth_headers):
+        session = client.post(
+            "/link/sessions",
+            params={"site": "internal_bank"},
+            headers=auth_headers,
+        ).json()
+        link_token = session["link_token"]
+
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={
+                "event": "INSTITUTION_SELECTED",
+                "site": "internal_bank",
+                "access_token": "should-not-persist",
+                "result": {"leak": True},
+            },
+        )
+        assert response.status_code == 200
+
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        # Status response never contains access_token or result.
+        assert "access_token" not in status
+        assert "result" not in status


### PR DESCRIPTION
Closes #48. Part of epic #47.

## Problem
Hosted Link completion contract says browser/mobile clients must only receive `public_token` + metadata on CONNECTED. Even though current callers already comply, nothing at the event-emission boundary prevents a future caller from leaking `access_token`, raw extracted `result` data, passwords, or private keys into hosted-link events consumed by iframe parents, ReactNativeWebView, WKWebView, or the SSE stream.

## Change
- Add `_sanitize_hosted_event_data()` in `src/routers/link_sessions.py` and apply it inside `_build_link_session_event` so every hosted-link event flowing to browser/mobile clients is scrubbed of forbidden keys: `access_token`, `accessToken`, `password`, `password_encrypted`, `username_encrypted`, `private_key`, `secret`, `result`, `data`.
- Apply the same sanitizer to incoming bodies of `POST /link/sessions/{token}/event`.
- Add unit tests covering the sanitizer, event builder, and `/event` endpoint behaviour.

## Validation
- New: `tests/test_links.py::TestHostedLinkEventSanitization` (3 tests)
- `tests/test_links.py` — 18 passed
- `tests/test_api_smoke.py tests/test_consent.py tests/test_hosted_link_e2e.py` — 30 passed (including the Playwright hosted-link web journey which asserts no access_token in any postMessage payload)