### PR TITLE
fix(hosted-link): per-session multi-origin frame-ancestors (#49)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -334,8 +334,18 @@ async def security_headers_middleware(request: Request, call_next):
         link_token = request.query_params.get("token")
         if link_token:
             session = session_store.get_link_session(link_token)
-            if session and session.get("allowed_origin"):
-                frame_ancestors = f"'self' {session['allowed_origin']}"
+            if session:
+                origins: list[str] = []
+                seen: set[str] = set()
+                for candidate in list(session.get("allowed_origins") or []) + [session.get("allowed_origin")]:
+                    if not candidate:
+                        continue
+                    normalized = candidate.rstrip("/")
+                    if normalized and normalized not in seen:
+                        seen.add(normalized)
+                        origins.append(normalized)
+                if origins:
+                    frame_ancestors = " ".join(["'self'", *origins])
 
     response.headers["X-Content-Type-Options"] = "nosniff"
     if is_hosted_link_html and frame_ancestors != "'self'":

--- a/src/auth_utils.py
+++ b/src/auth_utils.py
@@ -49,6 +49,7 @@ def create_link_launch_token(
     user_id: int,
     site: Optional[str] = None,
     allowed_origin: Optional[str] = None,
+    allowed_origins: Optional[list[str]] = None,
     scopes: Optional[list[str]] = None,
     expires_seconds: Optional[int] = None,
 ) -> str:
@@ -66,6 +67,8 @@ def create_link_launch_token(
         payload["site"] = site
     if allowed_origin:
         payload["allowed_origin"] = allowed_origin.rstrip("/")
+    if allowed_origins:
+        payload["allowed_origins"] = [entry.rstrip("/") for entry in allowed_origins]
     if scopes is not None:
         payload["scopes"] = scopes
 

--- a/src/models.py
+++ b/src/models.py
@@ -193,36 +193,55 @@ class BlueprintInfoResponse(BaseModel):
 # ── Hosted Link Bootstrap Models ────────────────────────────────────────────
 
 
+def _normalize_allowed_origin_value(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return value
+    normalized = value.strip().rstrip("/")
+    if not normalized:
+        return None
+
+    parsed = urlparse(normalized)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.path not in {"", "/"}
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("allowed_origin must be an http(s) origin without a path, query, or fragment.")
+
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
 class HostedLinkBootstrapRequest(BaseModel):
     """Request body for POST /link/bootstrap."""
 
     site: Optional[str] = Field(default=None, min_length=1, max_length=64)
     allowed_origin: Optional[str] = Field(default=None, max_length=512)
+    allowed_origins: Optional[list[str]] = Field(default=None, max_length=20)
     scopes: Optional[list[str]] = Field(default=None, max_length=100)
 
     @field_validator("allowed_origin")
     @classmethod
     def normalize_allowed_origin(cls, value: Optional[str]) -> Optional[str]:
+        return _normalize_allowed_origin_value(value)
+
+    @field_validator("allowed_origins")
+    @classmethod
+    def normalize_allowed_origins(cls, value: Optional[list[str]]) -> Optional[list[str]]:
         if value is None:
             return value
-        normalized = value.strip().rstrip("/")
-        if not normalized:
-            return None
-
-        parsed = urlparse(normalized)
-        if (
-            parsed.scheme not in {"http", "https"}
-            or not parsed.netloc
-            or parsed.path not in {"", "/"}
-            or parsed.params
-            or parsed.query
-            or parsed.fragment
-            or parsed.username is not None
-            or parsed.password is not None
-        ):
-            raise ValueError("allowed_origin must be an http(s) origin without a path, query, or fragment.")
-
-        return f"{parsed.scheme}://{parsed.netloc}"
+        normalized: list[str] = []
+        seen: set[str] = set()
+        for item in value:
+            entry = _normalize_allowed_origin_value(item)
+            if entry and entry not in seen:
+                seen.add(entry)
+                normalized.append(entry)
+        return normalized or None
 
 
 class HostedLinkBootstrapResponse(BaseModel):
@@ -232,6 +251,7 @@ class HostedLinkBootstrapResponse(BaseModel):
     expires_in: int
     site: Optional[str] = None
     allowed_origin: Optional[str] = None
+    allowed_origins: Optional[list[str]] = None
     scopes: Optional[list[str]] = None
 
 

--- a/src/routers/link_sessions.py
+++ b/src/routers/link_sessions.py
@@ -122,6 +122,7 @@ def _create_ephemeral_link_session(
     db: Optional[Session],
     scopes: Optional[list[str]],
     allowed_origin: Optional[str],
+    allowed_origins: Optional[list[str]] = None,
 ) -> Dict[str, Any]:
     """Create a hosted link session and its ephemeral encryption material."""
     link_token = str(uuid.uuid4())
@@ -136,11 +137,24 @@ def _create_ephemeral_link_session(
     if scopes is not None:
         session_store.set_link_scopes(link_token, json.dumps(scopes))
 
+    normalized_primary = _normalize_origin(allowed_origin)
+    normalized_list: list[str] = []
+    seen: set[str] = set()
+    if normalized_primary:
+        normalized_list.append(normalized_primary)
+        seen.add(normalized_primary)
+    for entry in allowed_origins or []:
+        normalized_entry = _normalize_origin(entry)
+        if normalized_entry and normalized_entry not in seen:
+            seen.add(normalized_entry)
+            normalized_list.append(normalized_entry)
+
     session_store.create_link_session(
         link_token,
         {
             "status": "awaiting_institution",
-            "allowed_origin": _normalize_origin(allowed_origin),
+            "allowed_origin": normalized_primary,
+            "allowed_origins": normalized_list,
             "current_job_id": None,
             "error_message": None,
             "site": site,
@@ -481,6 +495,7 @@ async def create_link_bootstrap(
         user_id=user.id,
         site=body.site,
         allowed_origin=body.allowed_origin,
+        allowed_origins=body.allowed_origins,
         scopes=effective_scopes,
         expires_seconds=expires_in,
     )
@@ -504,6 +519,7 @@ async def create_link_bootstrap(
         expires_in=expires_in,
         site=body.site,
         allowed_origin=body.allowed_origin,
+        allowed_origins=body.allowed_origins,
         scopes=effective_scopes,
     )
 
@@ -523,8 +539,12 @@ async def exchange_link_bootstrap(
         raise HTTPException(status_code=400, detail="Invalid link bootstrap token.")
 
     allowed_origin = payload.get("allowed_origin")
+    allowed_origins_payload = payload.get("allowed_origins") or []
     request_origin = _extract_request_origin(request)
-    if allowed_origin and request_origin != allowed_origin:
+    allowed_set = {entry.rstrip("/") for entry in allowed_origins_payload if entry}
+    if allowed_origin:
+        allowed_set.add(allowed_origin.rstrip("/"))
+    if allowed_set and (request_origin is None or request_origin.rstrip("/") not in allowed_set):
         raise HTTPException(
             status_code=403,
             detail="This origin is not allowed to redeem the hosted-link bootstrap token.",
@@ -551,6 +571,7 @@ async def exchange_link_bootstrap(
         db=db,
         scopes=scopes,
         allowed_origin=allowed_origin,
+        allowed_origins=allowed_origins_payload,
     )
 
     logger.info(

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -302,3 +302,98 @@ class TestHostedLinkEventSanitization:
         # Status response never contains access_token or result.
         assert "access_token" not in status
         assert "result" not in status
+
+
+class TestHostedLinkFrameAncestors:
+    """Verify hosted /link CSP frame-ancestors is derived from per-session allowlist."""
+
+    def test_link_html_no_token_defaults_to_self(self, client):
+        response = client.get("/link")
+        assert response.status_code == 200
+        csp = response.headers.get("Content-Security-Policy", "")
+        assert "frame-ancestors 'self'" in csp
+        # Hard default stays SAMEORIGIN when no session allowlist is present.
+        assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+
+    def test_link_html_with_unknown_token_defaults_to_self(self, client):
+        response = client.get("/link?token=does-not-exist")
+        assert response.status_code == 200
+        csp = response.headers.get("Content-Security-Policy", "")
+        assert "frame-ancestors 'self'" in csp
+        assert response.headers.get("X-Frame-Options") == "SAMEORIGIN"
+
+    def test_link_html_uses_session_allowed_origin(self, client, auth_headers):
+        session = client.post(
+            "/link/sessions",
+            params={"site": "internal_bank"},
+            headers={**auth_headers, "Origin": "https://partner.example.com"},
+        ).json()
+        link_token = session["link_token"]
+
+        response = client.get(f"/link?token={link_token}")
+        csp = response.headers.get("Content-Security-Policy", "")
+        assert "frame-ancestors 'self' https://partner.example.com" in csp
+        # X-Frame-Options removed so the document can be framed cross-origin.
+        assert "X-Frame-Options" not in response.headers
+
+    def test_bootstrap_multi_origin_allowlist(self, client, auth_headers):
+        bootstrap = client.post(
+            "/link/bootstrap",
+            json={
+                "site": "internal_bank",
+                "allowed_origins": [
+                    "https://partner-a.example.com",
+                    "https://partner-b.example.com/",
+                    "https://partner-a.example.com",
+                ],
+            },
+            headers=auth_headers,
+        )
+        assert bootstrap.status_code == 200
+        body = bootstrap.json()
+        assert body["allowed_origins"] == [
+            "https://partner-a.example.com",
+            "https://partner-b.example.com",
+        ]
+
+        exchange = client.post(
+            "/link/sessions/bootstrap",
+            json={"launch_token": body["launch_token"]},
+            headers={"Origin": "https://partner-b.example.com"},
+        )
+        assert exchange.status_code == 200
+        link_token = exchange.json()["link_token"]
+
+        response = client.get(f"/link?token={link_token}")
+        csp = response.headers.get("Content-Security-Policy", "")
+        assert "https://partner-a.example.com" in csp
+        assert "https://partner-b.example.com" in csp
+        assert "X-Frame-Options" not in response.headers
+
+    def test_bootstrap_rejects_origin_outside_allowlist(self, client, auth_headers):
+        bootstrap = client.post(
+            "/link/bootstrap",
+            json={
+                "site": "internal_bank",
+                "allowed_origins": ["https://partner-a.example.com"],
+            },
+            headers=auth_headers,
+        ).json()
+
+        exchange = client.post(
+            "/link/sessions/bootstrap",
+            json={"launch_token": bootstrap["launch_token"]},
+            headers={"Origin": "https://attacker.example.com"},
+        )
+        assert exchange.status_code == 403
+
+    def test_bootstrap_rejects_invalid_origin_format(self, client, auth_headers):
+        response = client.post(
+            "/link/bootstrap",
+            json={
+                "site": "internal_bank",
+                "allowed_origins": ["not-a-valid-origin"],
+            },
+            headers=auth_headers,
+        )
+        assert response.status_code == 422


### PR DESCRIPTION
Closes #49. Part of epic #47.

## Problem
Hosted `/link` pages must be embeddable by the partner origins listed on the link session, but the middleware only honoured a single `allowed_origin` and defaulted the rest of the responses to `X-Frame-Options: SAMEORIGIN` + CSP `frame-ancestors 'self'`. That broke legitimate multi-origin embeds.

## Change
- `HostedLinkBootstrapRequest` / `Response`: new `allowed_origins: list[str]` field with the same validation as `allowed_origin`, deduped and normalized. Legacy `allowed_origin` still accepted.
- `create_link_launch_token`: persists `allowed_origins` in the signed JWT.
- `_create_ephemeral_link_session`: persists a normalized `allowed_origins` list on the session payload.
- `/link/sessions/bootstrap`: verifies the redeeming request `Origin` is in the allowlist (accepts either legacy `allowed_origin` or the new list).
- `security_headers_middleware` in `src/app.py`: emits `frame-ancestors 'self' <origin1> <origin2> …` for `/link` and `/ui/link.html` when a session allowlist is present, and strips `X-Frame-Options` so the document can be framed cross-origin.

## Validation
- New: `tests/test_links.py::TestHostedLinkFrameAncestors` (6 cases: no-session, unknown-token, single-origin, multi-origin, out-of-allowlist, invalid-origin-format).
- `tests/test_links.py tests/test_hosted_link_e2e.py tests/test_api_smoke.py tests/test_consent.py tests/test_main.py` — 57 passed.