### PR TITLE
fix(hosted-link): reliable lifecycle event delivery + OPEN/EXIT coverage (#50)

### DIFF
--- a/frontend/link-page.js
+++ b/frontend/link-page.js
@@ -320,15 +320,78 @@
     return payload;
   }
 
-  async function bestEffortLinkEvent(eventName, payload) {
+  // Durable event delivery: hosted-link lifecycle events must reach the
+  // server so session state, SSE, and webhooks stay in sync with what the
+  // user actually did in the browser. We queue posts and retry with
+  // exponential backoff; persistent failures are surfaced to the UI.
+  const eventDelivery = {
+    queue: [],
+    inFlight: false,
+    retryTimer: null,
+  };
+
+  function scheduleEventRetry(delayMs) {
+    if (eventDelivery.retryTimer) {
+      return;
+    }
+    eventDelivery.retryTimer = window.setTimeout(() => {
+      eventDelivery.retryTimer = null;
+      drainEventQueue();
+    }, delayMs);
+  }
+
+  async function drainEventQueue() {
+    if (eventDelivery.inFlight || !linkToken) {
+      return;
+    }
+    const next = eventDelivery.queue[0];
+    if (!next) {
+      return;
+    }
+    eventDelivery.inFlight = true;
+    try {
+      await apiCall(
+        "POST",
+        `/link/sessions/${encodeURIComponent(linkToken)}/event`,
+        Object.assign({ event: next.event }, next.payload || {}),
+      );
+      eventDelivery.queue.shift();
+      eventDelivery.inFlight = false;
+      if (eventDelivery.queue.length) {
+        drainEventQueue();
+      }
+    } catch (error) {
+      eventDelivery.inFlight = false;
+      next.attempts = (next.attempts || 0) + 1;
+      const maxAttempts = 6;
+      if (next.attempts >= maxAttempts) {
+        eventDelivery.queue.shift();
+        // Surface a visible error so the parent app/operator knows
+        // lifecycle state may have diverged from the server.
+        try {
+          postEvent("EVENT_DELIVERY_FAILED", {
+            failed_event: next.event,
+            error: error?.message || "event delivery failed",
+          });
+        } catch (_) {
+          // best-effort telemetry only
+        }
+        if (eventDelivery.queue.length) {
+          drainEventQueue();
+        }
+        return;
+      }
+      const backoff = Math.min(250 * 2 ** (next.attempts - 1), 4000);
+      scheduleEventRetry(backoff);
+    }
+  }
+
+  function bestEffortLinkEvent(eventName, payload) {
     if (!linkToken) {
       return;
     }
-    try {
-      await apiCall("POST", `/link/sessions/${encodeURIComponent(linkToken)}/event`, Object.assign({ event: eventName }, payload || {}));
-    } catch (_) {
-      // Ignore because hosted link pages can operate without a bearer token.
-    }
+    eventDelivery.queue.push({ event: eventName, payload, attempts: 0 });
+    drainEventQueue();
   }
 
   function buildSearchPath(overrides) {
@@ -1081,12 +1144,14 @@
   });
   document.getElementById("close-btn").addEventListener("click", () => {
     postEvent("EXIT", { reason: "user_closed" });
+    bestEffortLinkEvent("EXIT", { reason: "user_closed" });
     closeWindow();
   });
 
   document.addEventListener("keydown", (event) => {
     if (event.key === "Escape") {
       postEvent("EXIT", { reason: "user_pressed_escape" });
+      bestEffortLinkEvent("EXIT", { reason: "user_pressed_escape" });
       closeWindow();
     }
   });
@@ -1096,6 +1161,8 @@
     if (!valid) {
       return;
     }
+    postEvent("OPEN", {});
+    bestEffortLinkEvent("OPEN", {});
     await loadInitialOrganizations();
   }
 

--- a/src/routers/link_sessions.py
+++ b/src/routers/link_sessions.py
@@ -270,8 +270,10 @@ async def _push_link_session_event(
     await _publish_link_session_event(link_token, event_data)
 
     webhook_event_map = {
+        "OPEN": "LINK_OPEN",
         "CONNECTED": "LINK_COMPLETE",
         "ERROR": "LINK_ERROR",
+        "EXIT": "LINK_EXIT",
         "MFA_REQUIRED": "MFA_REQUIRED",
     }
     if event_name in webhook_event_map:
@@ -630,7 +632,12 @@ async def post_link_session_event(
         {k: v for k, v in body.items() if k != "event"}
     )
     updates = {}
-    if event_name == "INSTITUTION_SELECTED":
+    if event_name == "OPEN":
+        # Page loaded; no session-state transition required but event is
+        # still recorded and fanned out to SSE/webhooks so developers can
+        # observe when the user actually saw the Link modal.
+        pass
+    elif event_name == "INSTITUTION_SELECTED":
         updates["status"] = "awaiting_credentials"
         updates["site"] = body.get("site", session.get("site"))
     elif event_name == "CREDENTIALS_SUBMITTED":
@@ -639,11 +646,20 @@ async def post_link_session_event(
         updates["status"] = "mfa_required"
     elif event_name == "MFA_SUBMITTED":
         updates["status"] = "verifying_mfa"
+    elif event_name == "EXIT":
+        # Only transition to exited if not already terminal; preserves
+        # completed/error states when the page unloads after success/failure.
+        if session.get("status") not in {"completed", "error", "expired"}:
+            updates["status"] = "exited"
     elif event_name == "ERROR":
         updates["status"] = "error"
         updates["error_message"] = body.get("error")
 
     if event_name == "CONNECTED":
+        # CONNECTED is authoritative from the server-side job reconciler,
+        # not from the browser, to prevent a client from lying about a
+        # successful completion. We still 200 so the page's retry queue
+        # treats the write as durable.
         return {"status": "ignored"}
 
     await _push_link_session_event(

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -397,3 +397,119 @@ class TestHostedLinkFrameAncestors:
             headers=auth_headers,
         )
         assert response.status_code == 422
+
+
+class TestHostedLinkEventEndpoint:
+    """Full lifecycle coverage for POST /link/sessions/{token}/event.
+
+    Verifies that anonymous browser posts (authed by the link_token
+    capability) update session_state for every observable event so
+    webhooks and SSE cannot silently diverge from what the user saw.
+    """
+
+    def _create_session(self, client, auth_headers):
+        return client.post(
+            "/link/sessions",
+            params={"site": "internal_bank"},
+            headers=auth_headers,
+        ).json()["link_token"]
+
+    def test_unknown_token_returns_404(self, client):
+        response = client.post(
+            "/link/sessions/does-not-exist/event",
+            json={"event": "OPEN"},
+        )
+        assert response.status_code == 404
+
+    def test_open_event_records_but_does_not_transition(self, client, auth_headers):
+        link_token = self._create_session(client, auth_headers)
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "OPEN"},
+        )
+        assert response.status_code == 200
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert "OPEN" in status["events"]
+        assert status["status"] == "awaiting_institution"
+
+    def test_institution_selected_transitions_state(self, client, auth_headers):
+        link_token = self._create_session(client, auth_headers)
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "INSTITUTION_SELECTED", "site": "internal_bank"},
+        )
+        assert response.status_code == 200
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert status["status"] == "awaiting_credentials"
+
+    def test_credentials_submitted_transitions_state(self, client, auth_headers):
+        link_token = self._create_session(client, auth_headers)
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "CREDENTIALS_SUBMITTED"},
+        )
+        assert response.status_code == 200
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert status["status"] == "connecting"
+
+    def test_mfa_events_transition_state(self, client, auth_headers):
+        link_token = self._create_session(client, auth_headers)
+        client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "MFA_REQUIRED", "mfa_type": "otp"},
+        )
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert status["status"] == "mfa_required"
+
+        client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "MFA_SUBMITTED"},
+        )
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert status["status"] == "verifying_mfa"
+
+    def test_connected_is_authoritative_server_side(self, client, auth_headers):
+        link_token = self._create_session(client, auth_headers)
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "CONNECTED", "public_token": "should-not-trust"},
+        )
+        # Browser-reported CONNECTED is intentionally ignored so a client
+        # cannot lie about completion; page retry queue still sees 2xx.
+        assert response.status_code == 200
+        assert response.json() == {"status": "ignored"}
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert status["status"] == "awaiting_institution"
+
+    def test_exit_event_marks_session_exited(self, client, auth_headers):
+        link_token = self._create_session(client, auth_headers)
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "EXIT", "reason": "user_closed"},
+        )
+        assert response.status_code == 200
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert status["status"] == "exited"
+
+    def test_error_event_marks_session_error(self, client, auth_headers):
+        link_token = self._create_session(client, auth_headers)
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "ERROR", "error": "provider refused"},
+        )
+        assert response.status_code == 200
+        status = client.get(f"/link/sessions/{link_token}/status").json()
+        assert status["status"] == "error"
+        assert status["error_message"] == "provider refused"
+
+    def test_event_endpoint_requires_no_user_auth(self, client, auth_headers):
+        # The endpoint is deliberately authed by the link_token capability,
+        # not by a user JWT, because it is called from the anonymous
+        # hosted page.
+        link_token = self._create_session(client, auth_headers)
+        response = client.post(
+            f"/link/sessions/{link_token}/event",
+            json={"event": "INSTITUTION_SELECTED", "site": "internal_bank"},
+            # no auth headers at all
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
Closes #50. Part of epic #47.

## Problem
The hosted `/link` page posts lifecycle events anonymously (authed by the `link_token` capability). Failures were silently swallowed by `bestEffortLinkEvent`, and `OPEN` / `EXIT` were never posted to the server, so session state, SSE streams, and webhooks could diverge from what the user actually saw and did.

## Server changes (`src/routers/link_sessions.py`)
- Handle `OPEN`: record + fanout, no state transition.
- Handle `EXIT`: mark session `exited` unless already terminal (`completed`/`error`/`expired`).
- Extend `webhook_event_map` with `LINK_OPEN` and `LINK_EXIT`.
- `CONNECTED` remains server-authoritative — browser-reported `CONNECTED` returns 200 + `{'status':'ignored'}` so the page's retry queue treats it as durable while a malicious client cannot fake completion.

## Frontend changes (`frontend/link-page.js`)
- Replaced fire-and-forget `bestEffortLinkEvent` with a durable retry queue: exponential backoff (250ms → 4s), up to 6 attempts. On exhaustion the page emits `EVENT_DELIVERY_FAILED` via `postEvent` so the embedding app can react.
- Post `OPEN` on init and `EXIT` on close/escape so the server sees the full lifecycle.

## Validation
- New: `tests/test_links.py::TestHostedLinkEventEndpoint` (9 cases: unknown-token 404, OPEN, INSTITUTION_SELECTED, CREDENTIALS_SUBMITTED, MFA_REQUIRED, MFA_SUBMITTED, CONNECTED-ignored, EXIT, ERROR, anonymous-capability auth).
- `tests/test_links.py tests/test_hosted_link_e2e.py` — 36 passed.
- Full suite: 736 passed / 1 pre-existing flaky test unrelated to this change (`test_scheduled_refresh.py::TestRefreshScheduler::test_start_stop`; passes in isolation, event-loop timing with `unittest.mock`).