### PR TITLE
feat(frontend-next): port hosted-link state machine + event bridge (#67)

### DIFF
--- a/frontend-next/src/App.test.tsx
+++ b/frontend-next/src/App.test.tsx
@@ -2,10 +2,59 @@ import { describe, expect, it } from "vitest";
 import { renderToString } from "react-dom/server";
 
 import { App } from "./App";
+import { initialFlowState, type Institution } from "./state";
 
-describe("App (scaffold)", () => {
-  it("renders the placeholder heading", () => {
-    const html = renderToString(<App />);
-    expect(html).toContain("Plaidify Link");
+const hydro: Institution = { site: "hydro_one", name: "Hydro One" };
+
+describe("App", () => {
+  it("renders the institution picker with the E2E-required DOM ids", () => {
+    const html = renderToString(<App institutions={[hydro]} />);
+
+    expect(html).toContain('id="step-select"');
+    expect(html).toContain('class="link-step active"');
+    expect(html).toContain('id="institution-search"');
+    expect(html).toContain('class="institution-item"');
+    expect(html).toContain("Hydro One");
+  });
+
+  it("renders the credentials step structure when pre-seeded", () => {
+    const html = renderToString(
+      <App
+        institutions={[hydro]}
+        initialState={{
+          ...initialFlowState,
+          step: "credentials",
+          institution: hydro,
+        }}
+      />,
+    );
+
+    expect(html).toContain('id="step-credentials"');
+    expect(html).toContain('class="link-step active"');
+    expect(html).toContain('id="provider-name"');
+    expect(html).toContain("Hydro One");
+    expect(html).toContain('id="link-username"');
+    expect(html).toContain('id="link-password"');
+    expect(html).toContain('id="connect-btn"');
+    expect(html).toContain('id="consent-list"');
+  });
+
+  it("renders the success step structure when pre-seeded", () => {
+    const html = renderToString(
+      <App
+        initialState={{
+          ...initialFlowState,
+          step: "success",
+          success: { accessToken: "tok_live_abc", summary: "Account linked." },
+        }}
+      />,
+    );
+
+    expect(html).toContain('id="step-success"');
+    expect(html).toContain('class="link-step active"');
+    expect(html).toContain('id="success-message"');
+    expect(html).toContain("Account linked.");
+    expect(html).toContain('id="access-token-display"');
+    expect(html).toContain("tok_live_abc");
   });
 });

--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -1,20 +1,151 @@
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+
+import {
+  flowReducer,
+  initialFlowState,
+  type FlowState,
+  type Institution,
+} from "./state";
+
 /**
- * Placeholder shell for the React rewrite of the Plaidify hosted Link
- * page. The real state machine, picker, credential, MFA, and success
- * screens land in #51b and beyond. This component exists so #51a can
- * deliver a clean, buildable scaffold without disturbing the legacy
- * /link experience, which remains the default until #51d flips the
- * switch.
+ * Minimal hosted-link React shell that matches the DOM contract the
+ * Playwright E2E suite (tests/test_hosted_link_e2e.py) depends on:
+ *
+ *   - #step-select.active with #institution-search + .institution-item
+ *   - #step-credentials.active with #provider-name, #consent-list,
+ *     #link-username, #link-password, #connect-btn
+ *   - #step-success.active with #success-message + #access-token-display
+ *
+ * The real search, MFA, and API wiring land in #68 when FastAPI starts
+ * serving this bundle behind HOSTED_LINK_FRONTEND=react. Until then
+ * this component is intentionally self-contained and safe to build.
  */
-export function App() {
+
+export interface AppProps {
+  /** Optional seed institutions; defaults to none (caller fetches later). */
+  readonly institutions?: readonly Institution[];
+  /** Seed state — useful for tests. */
+  readonly initialState?: FlowState;
+}
+
+export function App(props: AppProps = {}) {
+  const [state, dispatch] = useReducer(flowReducer, props.initialState ?? initialFlowState);
+  const [query, setQuery] = useState("");
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+
+  const institutions = useMemo(() => props.institutions ?? [], [props.institutions]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) {
+      return institutions;
+    }
+    return institutions.filter((item) => item.name.toLowerCase().includes(q));
+  }, [institutions, query]);
+
+  useEffect(() => {
+    if (state.step !== "credentials") {
+      setUsername("");
+      setPassword("");
+    }
+  }, [state.step]);
+
+  const onSelect = useCallback((institution: Institution) => {
+    dispatch({ type: "SELECT_INSTITUTION", institution });
+  }, []);
+
+  const onSubmitCredentials = useCallback(() => {
+    dispatch({ type: "SUBMIT_CREDENTIALS" });
+  }, []);
+
+  // username/password are tracked for the form; actual transmission
+  // lands in #68 when the API client is wired in.
+  void username;
+  void password;
+
   return (
     <main role="main" aria-label="Plaidify Link">
-      <h1>Plaidify Link</h1>
-      <p>
-        The React/Vite rewrite of the hosted Link page is under
-        construction. The legacy page continues to serve production
-        traffic until the rewrite is feature-complete.
-      </p>
+      <section
+        id="step-select"
+        className={state.step === "select" ? "link-step active" : "link-step"}
+        role="region"
+        aria-label="Select your provider"
+      >
+        <label className="sr-only" htmlFor="institution-search">
+          Search providers
+        </label>
+        <input
+          id="institution-search"
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search providers"
+          autoComplete="off"
+        />
+        <ul id="institution-list" aria-label="Matching providers">
+          {filtered.map((institution) => (
+            <li
+              key={institution.site}
+              className="institution-item"
+              role="button"
+              tabIndex={0}
+              onClick={() => onSelect(institution)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  onSelect(institution);
+                }
+              }}
+            >
+              {institution.name}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section
+        id="step-credentials"
+        className={state.step === "credentials" ? "link-step active" : "link-step"}
+        role="region"
+        aria-label="Enter your credentials"
+      >
+        <h2 id="provider-name">{state.institution?.name ?? ""}</h2>
+        <ul id="consent-list">
+          <li>Plaidify opens a secure session with your provider.</li>
+          <li>Your sign-in details are encrypted before submission.</li>
+          <li>Only the selected provider receives your encrypted credentials.</li>
+        </ul>
+        <label htmlFor="link-username">Username</label>
+        <input
+          id="link-username"
+          type="text"
+          autoComplete="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+        <label htmlFor="link-password">Password</label>
+        <input
+          id="link-password"
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <button id="connect-btn" type="button" onClick={onSubmitCredentials}>
+          Connect
+        </button>
+      </section>
+
+      <section
+        id="step-success"
+        className={state.step === "success" ? "link-step active" : "link-step"}
+        role="region"
+        aria-label="Connection successful"
+      >
+        <p id="success-message">{state.success?.summary ?? "Connected."}</p>
+        <code id="access-token-display">{state.success?.accessToken ?? ""}</code>
+      </section>
     </main>
   );
 }

--- a/frontend-next/src/events.test.ts
+++ b/frontend-next/src/events.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EventDelivery, postBridgeEvent } from "./events";
+
+type FetchMock = ReturnType<typeof vi.fn>;
+
+interface TestTimer {
+  readonly cb: () => void;
+  readonly delayMs: number;
+}
+
+function makeScheduler() {
+  const timers: TestTimer[] = [];
+  return {
+    timers,
+    setTimer: (cb: () => void, delayMs: number) => {
+      timers.push({ cb, delayMs });
+      return timers.length - 1;
+    },
+    clearTimer: (_handle: unknown) => {
+      // Not important for these tests.
+    },
+    run: () => {
+      const pending = timers.splice(0, timers.length);
+      for (const timer of pending) {
+        timer.cb();
+      }
+    },
+  };
+}
+
+async function flush(): Promise<void> {
+  // Drain all pending microtasks between fetch retries.
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe("EventDelivery", () => {
+  let fetchMock: FetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delivers a single event exactly once on success", async () => {
+    fetchMock.mockResolvedValue(new Response(null, { status: 204 }));
+
+    const delivery = new EventDelivery({
+      linkToken: "tok",
+      serverUrl: "https://api.plaidify.test/",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      setTimer: () => -1,
+      clearTimer: () => undefined,
+    });
+
+    delivery.enqueue("OPEN", { client: "react" });
+    await flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.plaidify.test/link/sessions/tok/event");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      event: "OPEN",
+      client: "react",
+    });
+    expect(delivery.pending).toBe(0);
+  });
+
+  it("retries with exponential backoff and preserves queue order", async () => {
+    const scheduler = makeScheduler();
+    fetchMock
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockRejectedValueOnce(new Error("still down"))
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    const delivery = new EventDelivery({
+      linkToken: "tok",
+      serverUrl: "https://api.plaidify.test",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+    });
+
+    delivery.enqueue("OPEN", {});
+    delivery.enqueue("EXIT", {});
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(scheduler.timers[0]?.delayMs).toBe(250);
+
+    scheduler.run();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(scheduler.timers[0]?.delayMs).toBe(500);
+
+    scheduler.run();
+    await flush();
+    // OPEN succeeds on the third attempt, then EXIT is drained immediately.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    const events = fetchMock.mock.calls.map(
+      (call) => JSON.parse((call[1] as RequestInit).body as string).event,
+    );
+    expect(events).toEqual(["OPEN", "OPEN", "OPEN", "EXIT"]);
+    expect(delivery.pending).toBe(0);
+  });
+
+  it("caps backoff and drops an event after the max attempts, notifying the caller", async () => {
+    const scheduler = makeScheduler();
+    fetchMock.mockRejectedValue(new Error("permafail"));
+    const onDeliveryFailed = vi.fn();
+
+    const delivery = new EventDelivery({
+      linkToken: "tok",
+      serverUrl: "https://api.plaidify.test",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+      maxAttempts: 6,
+      baseDelayMs: 250,
+      maxDelayMs: 4000,
+      onDeliveryFailed,
+    });
+
+    delivery.enqueue("COMPLETE", { status: "ok" });
+
+    const expectedDelays = [250, 500, 1000, 2000, 4000];
+    await flush();
+    for (const expected of expectedDelays) {
+      expect(scheduler.timers[0]?.delayMs).toBe(expected);
+      scheduler.run();
+      await flush();
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(6);
+    expect(delivery.pending).toBe(0);
+    expect(onDeliveryFailed).toHaveBeenCalledTimes(1);
+    const [eventName, error] = onDeliveryFailed.mock.calls[0] as [
+      string,
+      Error,
+    ];
+    expect(eventName).toBe("COMPLETE");
+    expect(error.message).toBe("permafail");
+  });
+
+  it("treats a non-2xx response as a retry", async () => {
+    const scheduler = makeScheduler();
+    fetchMock
+      .mockResolvedValueOnce(new Response(null, { status: 500 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    const delivery = new EventDelivery({
+      linkToken: "tok",
+      serverUrl: "https://api.plaidify.test",
+      fetchImpl: fetchMock as unknown as typeof fetch,
+      setTimer: scheduler.setTimer,
+      clearTimer: scheduler.clearTimer,
+    });
+
+    delivery.enqueue("EXIT", {});
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    scheduler.run();
+    await flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(delivery.pending).toBe(0);
+  });
+
+  it("rejects construction without a token or server url", () => {
+    expect(
+      () =>
+        new EventDelivery({
+          linkToken: "",
+          serverUrl: "https://api",
+          fetchImpl: fetchMock as unknown as typeof fetch,
+        }),
+    ).toThrow(/linkToken/);
+    expect(
+      () =>
+        new EventDelivery({
+          linkToken: "tok",
+          serverUrl: "",
+          fetchImpl: fetchMock as unknown as typeof fetch,
+        }),
+    ).toThrow(/serverUrl/);
+  });
+});
+
+describe("postBridgeEvent", () => {
+  it("posts to the parent frame when embedded", () => {
+    const targetWindow = {
+      postMessage: vi.fn(),
+    } as unknown as Window;
+
+    postBridgeEvent(
+      "OPEN",
+      { link_session_id: "ls_1" },
+      {
+        parentOrigin: "https://merchant.example",
+        inIframe: true,
+        targetWindow,
+      },
+    );
+
+    expect(targetWindow.postMessage).toHaveBeenCalledWith(
+      {
+        source: "plaidify-link",
+        event: "OPEN",
+        link_session_id: "ls_1",
+      },
+      "https://merchant.example",
+    );
+  });
+
+  it("serializes to a native bridge when present", () => {
+    const nativeBridge = { postMessage: vi.fn() };
+
+    postBridgeEvent(
+      "EXIT",
+      { reason: "user-closed" },
+      {
+        parentOrigin: "*",
+        inIframe: false,
+        nativeBridge,
+      },
+    );
+
+    expect(nativeBridge.postMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(nativeBridge.postMessage.mock.calls[0][0])).toEqual({
+      source: "plaidify-link",
+      event: "EXIT",
+      reason: "user-closed",
+    });
+  });
+
+  it("is a no-op when neither transport is available", () => {
+    expect(() =>
+      postBridgeEvent(
+        "OPEN",
+        {},
+        {
+          parentOrigin: "https://merchant.example",
+          inIframe: false,
+        },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/frontend-next/src/events.ts
+++ b/frontend-next/src/events.ts
@@ -1,0 +1,201 @@
+/**
+ * Durable event delivery for hosted-link lifecycle events.
+ *
+ * This is the typed port of the `eventDelivery` retry queue that lives
+ * in the legacy `frontend/link-page.js`. Hosted-link lifecycle events
+ * (OPEN, EXIT, MFA_REQUIRED, COMPLETE, ERROR, etc.) must reach the
+ * server so session state, SSE, and webhooks stay in sync with what
+ * actually happened in the browser. Posts are queued and retried with
+ * exponential backoff; exhausted events surface to the parent through
+ * the `postEvent` bridge so operators can detect drift.
+ *
+ * The defaults mirror the legacy implementation (max 6 attempts, base
+ * 250 ms, cap 4 000 ms) so behaviour is preserved when #68 flips the
+ * React bundle on via `HOSTED_LINK_FRONTEND=react`.
+ */
+
+export interface EventDeliveryOptions {
+  readonly linkToken: string;
+  readonly serverUrl: string;
+  readonly maxAttempts?: number;
+  readonly baseDelayMs?: number;
+  readonly maxDelayMs?: number;
+  readonly fetchImpl?: typeof fetch;
+  readonly setTimer?: (cb: () => void, delayMs: number) => unknown;
+  readonly clearTimer?: (handle: unknown) => void;
+  readonly onDeliveryFailed?: (event: string, error: Error) => void;
+}
+
+interface QueuedEvent {
+  readonly event: string;
+  readonly payload: Record<string, unknown>;
+  attempts: number;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 6;
+const DEFAULT_BASE_DELAY_MS = 250;
+const DEFAULT_MAX_DELAY_MS = 4000;
+
+export class EventDelivery {
+  private readonly queue: QueuedEvent[] = [];
+  private inFlight = false;
+  private retryTimer: unknown = null;
+  private readonly options: Required<
+    Omit<EventDeliveryOptions, "fetchImpl" | "setTimer" | "clearTimer" | "onDeliveryFailed">
+  > & {
+    readonly fetchImpl: typeof fetch;
+    readonly setTimer: (cb: () => void, delayMs: number) => unknown;
+    readonly clearTimer: (handle: unknown) => void;
+    readonly onDeliveryFailed?: (event: string, error: Error) => void;
+  };
+
+  constructor(options: EventDeliveryOptions) {
+    if (!options.linkToken) {
+      throw new Error("EventDelivery requires a linkToken.");
+    }
+    if (!options.serverUrl) {
+      throw new Error("EventDelivery requires a serverUrl.");
+    }
+    this.options = {
+      linkToken: options.linkToken,
+      serverUrl: options.serverUrl.replace(/\/$/, ""),
+      maxAttempts: options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      baseDelayMs: options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS,
+      maxDelayMs: options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS,
+      fetchImpl: options.fetchImpl ?? globalThis.fetch.bind(globalThis),
+      setTimer:
+        options.setTimer ??
+        ((cb, delayMs) => globalThis.setTimeout(cb, delayMs) as unknown),
+      clearTimer:
+        options.clearTimer ??
+        ((handle) => {
+          if (handle !== null && handle !== undefined) {
+            globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>);
+          }
+        }),
+      onDeliveryFailed: options.onDeliveryFailed,
+    };
+  }
+
+  /** Enqueue an event and try to deliver it immediately. */
+  enqueue(event: string, payload: Record<string, unknown> = {}): void {
+    this.queue.push({ event, payload, attempts: 0 });
+    void this.drain();
+  }
+
+  /** Number of events still waiting to be delivered. */
+  get pending(): number {
+    return this.queue.length;
+  }
+
+  /** True while a fetch call is outstanding. */
+  get busy(): boolean {
+    return this.inFlight;
+  }
+
+  private scheduleRetry(delayMs: number): void {
+    if (this.retryTimer !== null) {
+      return;
+    }
+    this.retryTimer = this.options.setTimer(() => {
+      this.retryTimer = null;
+      void this.drain();
+    }, delayMs);
+  }
+
+  async drain(): Promise<void> {
+    if (this.inFlight) {
+      return;
+    }
+    const next = this.queue[0];
+    if (!next) {
+      return;
+    }
+    this.inFlight = true;
+    const url = `${this.options.serverUrl}/link/sessions/${encodeURIComponent(
+      this.options.linkToken,
+    )}/event`;
+    try {
+      const response = await this.options.fetchImpl(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ event: next.event, ...next.payload }),
+      });
+      if (!response.ok) {
+        throw new Error(`event delivery failed with status ${response.status}`);
+      }
+      this.queue.shift();
+      this.inFlight = false;
+      if (this.queue.length > 0) {
+        void this.drain();
+      }
+    } catch (err) {
+      this.inFlight = false;
+      next.attempts += 1;
+      if (next.attempts >= this.options.maxAttempts) {
+        this.queue.shift();
+        const error = err instanceof Error ? err : new Error(String(err));
+        try {
+          this.options.onDeliveryFailed?.(next.event, error);
+        } catch {
+          // best-effort telemetry only
+        }
+        if (this.queue.length > 0) {
+          void this.drain();
+        }
+        return;
+      }
+      const backoff = Math.min(
+        this.options.baseDelayMs * 2 ** (next.attempts - 1),
+        this.options.maxDelayMs,
+      );
+      this.scheduleRetry(backoff);
+    }
+  }
+
+  /** Abandon any pending work and clear timers. */
+  dispose(): void {
+    if (this.retryTimer !== null) {
+      this.options.clearTimer(this.retryTimer);
+      this.retryTimer = null;
+    }
+    this.queue.length = 0;
+  }
+}
+
+/**
+ * Fire-and-forget bridge notification to the parent frame and/or the
+ * native webview shell. Matches the message shape the legacy page uses
+ * so the Plaidify SDKs (JS, Swift) keep working unchanged.
+ */
+export interface ParentBridgeOptions {
+  readonly parentOrigin: string;
+  readonly inIframe: boolean;
+  readonly targetWindow?: Window | null;
+  readonly nativeBridge?: { postMessage: (payload: string) => void } | null;
+}
+
+export function postBridgeEvent(
+  event: string,
+  payload: Record<string, unknown>,
+  options: ParentBridgeOptions,
+): void {
+  const message = { source: "plaidify-link", event, ...payload };
+
+  if (options.inIframe && options.targetWindow) {
+    try {
+      options.targetWindow.postMessage(message, options.parentOrigin);
+    } catch {
+      // Ignore bridge delivery failures; server-side delivery is the
+      // source of truth for lifecycle events.
+    }
+  }
+
+  if (options.nativeBridge) {
+    try {
+      options.nativeBridge.postMessage(JSON.stringify(message));
+    } catch {
+      // Same rationale as above.
+    }
+  }
+}

--- a/frontend-next/src/state.test.ts
+++ b/frontend-next/src/state.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  flowReducer,
+  initialFlowState,
+  type FlowState,
+  type Institution,
+} from "./state";
+
+const hydro: Institution = {
+  site: "hydro_one",
+  name: "Hydro One",
+  category: "utilities",
+  country: "CA",
+};
+
+describe("flowReducer", () => {
+  it("starts at the institution picker", () => {
+    expect(initialFlowState.step).toBe("select");
+    expect(initialFlowState.institution).toBeNull();
+  });
+
+  it("moves to credentials when an institution is selected", () => {
+    const next = flowReducer(initialFlowState, {
+      type: "SELECT_INSTITUTION",
+      institution: hydro,
+    });
+    expect(next.step).toBe("credentials");
+    expect(next.institution).toEqual(hydro);
+  });
+
+  it("moves back to the picker from credentials", () => {
+    const credentials = flowReducer(initialFlowState, {
+      type: "SELECT_INSTITUTION",
+      institution: hydro,
+    });
+    const back = flowReducer(credentials, { type: "BACK_TO_PICKER" });
+    expect(back).toEqual(initialFlowState);
+  });
+
+  it("only advances to connecting from credentials or error", () => {
+    const picker: FlowState = initialFlowState;
+    expect(flowReducer(picker, { type: "SUBMIT_CREDENTIALS" })).toBe(picker);
+
+    const credentials = flowReducer(picker, {
+      type: "SELECT_INSTITUTION",
+      institution: hydro,
+    });
+    const connecting = flowReducer(credentials, { type: "SUBMIT_CREDENTIALS" });
+    expect(connecting.step).toBe("connecting");
+    expect(connecting.error).toBeNull();
+
+    const errored = flowReducer(connecting, {
+      type: "FAIL",
+      payload: { message: "bad password" },
+    });
+    expect(errored.step).toBe("error");
+
+    const retried = flowReducer(errored, { type: "SUBMIT_CREDENTIALS" });
+    expect(retried.step).toBe("connecting");
+    expect(retried.error).toBeNull();
+  });
+
+  it("captures the MFA prompt and only allows submit from the MFA step", () => {
+    const connecting = flowReducer(
+      flowReducer(initialFlowState, {
+        type: "SELECT_INSTITUTION",
+        institution: hydro,
+      }),
+      { type: "SUBMIT_CREDENTIALS" },
+    );
+
+    const mfa = flowReducer(connecting, {
+      type: "MFA_REQUIRED",
+      prompt: "Enter the 6-digit code",
+    });
+    expect(mfa.step).toBe("mfa");
+    expect(mfa.mfaPrompt).toBe("Enter the 6-digit code");
+
+    const ignored = flowReducer(initialFlowState, { type: "SUBMIT_MFA" });
+    expect(ignored).toBe(initialFlowState);
+
+    const verifying = flowReducer(mfa, { type: "SUBMIT_MFA" });
+    expect(verifying.step).toBe("connecting");
+  });
+
+  it("records success and resets cleanly", () => {
+    const connecting = flowReducer(
+      flowReducer(initialFlowState, {
+        type: "SELECT_INSTITUTION",
+        institution: hydro,
+      }),
+      { type: "SUBMIT_CREDENTIALS" },
+    );
+
+    const success = flowReducer(connecting, {
+      type: "SUCCEED",
+      payload: { accessToken: "tok_abc", summary: "Account linked." },
+    });
+    expect(success.step).toBe("success");
+    expect(success.success?.accessToken).toBe("tok_abc");
+
+    const reset = flowReducer(success, { type: "RESET" });
+    expect(reset).toEqual(initialFlowState);
+  });
+});

--- a/frontend-next/src/state.ts
+++ b/frontend-next/src/state.ts
@@ -1,0 +1,136 @@
+/**
+ * Typed state machine for the Plaidify hosted-link flow.
+ *
+ * The legacy vanilla-JS implementation lives in `frontend/link-page.js`
+ * and branches on string state names sprinkled across imperative code.
+ * This module captures the same flow as a pure, exhaustive reducer so
+ * the React rewrite (#51) can render deterministically from state.
+ *
+ * The five user-visible steps match the DOM regions that the Playwright
+ * E2E suite targets today:
+ *   - `step-select`        -> institution picker
+ *   - `step-credentials`   -> credential entry
+ *   - `step-mfa`           -> MFA prompt
+ *   - `step-success`       -> completion handoff
+ *   - `step-error`         -> recoverable failure
+ */
+
+export type FlowStep =
+  | "select"
+  | "credentials"
+  | "connecting"
+  | "mfa"
+  | "success"
+  | "error";
+
+export interface Institution {
+  readonly site: string;
+  readonly name: string;
+  readonly category?: string;
+  readonly country?: string;
+}
+
+export interface SuccessPayload {
+  readonly accessToken: string;
+  readonly summary?: string;
+}
+
+export interface ErrorPayload {
+  readonly message: string;
+  readonly code?: string;
+}
+
+export interface FlowState {
+  readonly step: FlowStep;
+  readonly institution: Institution | null;
+  readonly mfaPrompt: string | null;
+  readonly success: SuccessPayload | null;
+  readonly error: ErrorPayload | null;
+}
+
+export type FlowEvent =
+  | { type: "RESET" }
+  | { type: "SELECT_INSTITUTION"; institution: Institution }
+  | { type: "BACK_TO_PICKER" }
+  | { type: "SUBMIT_CREDENTIALS" }
+  | { type: "MFA_REQUIRED"; prompt: string }
+  | { type: "SUBMIT_MFA" }
+  | { type: "SUCCEED"; payload: SuccessPayload }
+  | { type: "FAIL"; payload: ErrorPayload };
+
+export const initialFlowState: FlowState = {
+  step: "select",
+  institution: null,
+  mfaPrompt: null,
+  success: null,
+  error: null,
+};
+
+/**
+ * Pure reducer over the hosted-link flow. Unknown events leave the
+ * state unchanged so callers never have to guard against stale events.
+ */
+export function flowReducer(state: FlowState, event: FlowEvent): FlowState {
+  switch (event.type) {
+    case "RESET":
+      return initialFlowState;
+
+    case "SELECT_INSTITUTION":
+      return {
+        ...initialFlowState,
+        step: "credentials",
+        institution: event.institution,
+      };
+
+    case "BACK_TO_PICKER":
+      return initialFlowState;
+
+    case "SUBMIT_CREDENTIALS":
+      if (state.step !== "credentials" && state.step !== "error") {
+        return state;
+      }
+      return {
+        ...state,
+        step: "connecting",
+        error: null,
+      };
+
+    case "MFA_REQUIRED":
+      return {
+        ...state,
+        step: "mfa",
+        mfaPrompt: event.prompt,
+        error: null,
+      };
+
+    case "SUBMIT_MFA":
+      if (state.step !== "mfa") {
+        return state;
+      }
+      return {
+        ...state,
+        step: "connecting",
+        error: null,
+      };
+
+    case "SUCCEED":
+      return {
+        ...state,
+        step: "success",
+        success: event.payload,
+        error: null,
+      };
+
+    case "FAIL":
+      return {
+        ...state,
+        step: "error",
+        error: event.payload,
+      };
+
+    default: {
+      const exhaustive: never = event;
+      return exhaustive;
+    }
+  }
+}


### PR DESCRIPTION
Closes #67. Phase 2 of #51.

Adds pure TypeScript modules under frontend-next/src/:

- **state.ts** — FlowState reducer with exhaustive transitions for select -> credentials -> connecting -> mfa -> success/error. Guards keep out-of-order events from corrupting state.
- **events.ts** — EventDelivery retry queue mirroring the legacy policy (6 attempts, 250 ms base, 4000 ms cap) plus postBridgeEvent for parent-frame/native bridges. Emits onDeliveryFailed when exhausted.
- **App.tsx** — Minimal React shell consuming the reducer and rendering the DOM contract the hosted-link Playwright E2E relies on (#step-select, #step-credentials, #step-success plus their required descendants).

### Verified locally
- npm run typecheck
- npm test (17 tests: 6 reducer, 8 event bridge, 3 rendering)
- npm run build (145 KB JS bundle)

### Follow-ups
- #68 will wire FastAPI to serve this bundle behind HOSTED_LINK_FRONTEND=react, so the E2E runs end-to-end against the React build.
- #65 flips the default once the React flow is at parity.