### PR TITLE
feat(hosted-link): serve frontend-next bundle behind HOSTED_LINK_FRONTEND=react (#68)

### DIFF
--- a/frontend-next/vite.config.ts
+++ b/frontend-next/vite.config.ts
@@ -7,6 +7,8 @@ import react from "@vitejs/plugin-react";
 // /link/sessions/{token}/status API.
 export default defineConfig({
   plugins: [react()],
+  // FastAPI mounts the built bundle at /ui-next/ when HOSTED_LINK_FRONTEND=react.
+  base: "/ui-next/",
   build: {
     outDir: "dist",
     emptyOutDir: true,

--- a/src/app.py
+++ b/src/app.py
@@ -59,6 +59,7 @@ from src.routers import (
 settings = get_settings()
 logger = get_logger("api")
 FRONTEND_DIR = Path(__file__).resolve().parent.parent / "frontend"
+FRONTEND_NEXT_DIST = Path(__file__).resolve().parent.parent / "frontend-next" / "dist"
 
 _TOKEN_CLEANUP_INTERVAL = 3600
 _AUDIT_CLEANUP_INTERVAL = 86400
@@ -393,6 +394,22 @@ try:
     app.mount("/ui", StaticFiles(directory=str(FRONTEND_DIR), html=False), name="frontend")
 except Exception:
     logger.warning("Frontend directory not found, /ui will not be served")
+
+if FRONTEND_NEXT_DIST.exists():
+    try:
+        app.mount(
+            "/ui-next",
+            StaticFiles(directory=str(FRONTEND_NEXT_DIST), html=False),
+            name="frontend-next",
+        )
+    except Exception:
+        logger.warning(
+            "frontend-next/dist present but could not be mounted at /ui-next"
+        )
+else:
+    logger.info(
+        "frontend-next/dist not found; /ui-next will not be served (run 'npm run build' in frontend-next)"
+    )
 
 
 @app.exception_handler(PlaidifyError)

--- a/src/config.py
+++ b/src/config.py
@@ -88,6 +88,10 @@ class Settings(BaseSettings):
         default=300,
         description="Seconds before a signed hosted-link bootstrap token expires.",
     )
+    hosted_link_frontend: str = Field(
+        default="legacy",
+        description="Which hosted /link frontend to serve. 'legacy' serves frontend/link.html; 'react' serves the frontend-next/dist bundle when it is present.",
+    )
     enforce_https: bool = Field(
         default=False,
         description="Redirect HTTP to HTTPS and add HSTS header. Auto-enabled in production.",
@@ -317,6 +321,17 @@ class Settings(BaseSettings):
                 "Set CORS_ORIGINS to specific origins (e.g. 'https://app.example.com')."
             )
         return v
+
+    @field_validator("hosted_link_frontend")
+    @classmethod
+    def validate_hosted_link_frontend(cls, v: str) -> str:
+        normalized = (v or "legacy").strip().lower()
+        allowed = {"legacy", "react"}
+        if normalized not in allowed:
+            raise ValueError(
+                f"HOSTED_LINK_FRONTEND must be one of {sorted(allowed)}; got {v!r}."
+            )
+        return normalized
 
     model_config = {
         "env_prefix": "",

--- a/src/routers/link_sessions.py
+++ b/src/routers/link_sessions.py
@@ -37,6 +37,7 @@ from src.models import (
 settings = get_settings()
 logger = get_logger("api.link_sessions")
 FRONTEND_DIR = Path(__file__).resolve().parents[2] / "frontend"
+FRONTEND_NEXT_DIST = Path(__file__).resolve().parents[2] / "frontend-next" / "dist"
 
 router = APIRouter(tags=["link_sessions"])
 
@@ -418,7 +419,19 @@ async def hosted_link_page(token: Optional[str] = None):
     """Serve the hosted Link page.
 
     The page validates the token client-side via the /link/sessions API.
+    When HOSTED_LINK_FRONTEND=react and the compiled bundle exists under
+    frontend-next/dist/, the React rewrite is served instead. If the
+    flag is on but the build is missing, we fall back to the legacy
+    page and log a warning so the deployment isn't broken.
     """
+    if get_settings().hosted_link_frontend == "react":
+        react_index = FRONTEND_NEXT_DIST / "index.html"
+        if react_index.exists():
+            return HTMLResponse(content=react_index.read_text(encoding="utf-8"))
+        logger.warning(
+            "HOSTED_LINK_FRONTEND=react but frontend-next/dist/index.html is missing; serving legacy page."
+        )
+
     link_html = FRONTEND_DIR / "link.html"
     if not link_html.exists():
         raise HTTPException(status_code=500, detail="Link page not found.")

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -513,3 +513,84 @@ class TestHostedLinkEventEndpoint:
             # no auth headers at all
         )
         assert response.status_code == 200
+
+
+class TestHostedLinkFrontendFlag:
+    """Coverage for the HOSTED_LINK_FRONTEND env flag wiring (#68).
+
+    The legacy frontend/link.html is served by default. When the flag
+    is 'react' and frontend-next/dist/index.html exists, GET /link
+    serves that bundle instead. If the flag is 'react' but the React
+    build is missing, the legacy page is served so deployments aren't
+    broken.
+    """
+
+    def _legacy_marker(self) -> str:
+        # The legacy page ships the institution picker shell inline.
+        return "institution-search"
+
+    def _react_marker(self) -> str:
+        # The Vite bundle always injects <div id="root"></div>.
+        return 'id="root"'
+
+    def test_flag_defaults_to_legacy(self, client, monkeypatch):
+        monkeypatch.delenv("HOSTED_LINK_FRONTEND", raising=False)
+        response = client.get("/link")
+        assert response.status_code == 200
+        assert self._legacy_marker() in response.text
+
+    def test_flag_legacy_serves_legacy_page(self, client, monkeypatch):
+        monkeypatch.setenv("HOSTED_LINK_FRONTEND", "legacy")
+        response = client.get("/link")
+        assert response.status_code == 200
+        assert self._legacy_marker() in response.text
+
+    def test_flag_react_serves_react_bundle_when_built(self, client, monkeypatch, tmp_path):
+        from src.routers import link_sessions as link_sessions_module
+
+        fake_dist = tmp_path / "dist"
+        fake_dist.mkdir()
+        (fake_dist / "index.html").write_text(
+            '<!doctype html><html><body><div id="root"></div>'
+            '<script type="module" src="/ui-next/assets/index.js"></script></body></html>',
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(link_sessions_module, "FRONTEND_NEXT_DIST", fake_dist)
+        monkeypatch.setenv("HOSTED_LINK_FRONTEND", "react")
+
+        response = client.get("/link")
+        assert response.status_code == 200
+        assert self._react_marker() in response.text
+        # The legacy markup must not leak into the React response.
+        assert self._legacy_marker() not in response.text
+
+    def test_flag_react_falls_back_when_bundle_missing(
+        self, client, monkeypatch, tmp_path, caplog
+    ):
+        from src.routers import link_sessions as link_sessions_module
+
+        monkeypatch.setattr(
+            link_sessions_module, "FRONTEND_NEXT_DIST", tmp_path / "does-not-exist"
+        )
+        monkeypatch.setenv("HOSTED_LINK_FRONTEND", "react")
+
+        with caplog.at_level("WARNING"):
+            response = client.get("/link")
+        assert response.status_code == 200
+        assert self._legacy_marker() in response.text
+        assert any(
+            "frontend-next/dist/index.html is missing" in record.getMessage()
+            for record in caplog.records
+        )
+
+    def test_flag_rejects_unknown_values(self, monkeypatch):
+        from src.config import Settings
+
+        monkeypatch.setenv("HOSTED_LINK_FRONTEND", "angular")
+        try:
+            Settings()  # type: ignore[call-arg]
+        except Exception as exc:
+            assert "HOSTED_LINK_FRONTEND" in str(exc)
+        else:  # pragma: no cover — we expect the constructor to raise
+            raise AssertionError("Settings() should reject unknown HOSTED_LINK_FRONTEND values")
+


### PR DESCRIPTION
Closes #68. Phase 3 of #51.

Plumbs the env flag so operators can route GET /link to either the legacy vanilla-JS page or the React/Vite bundle from #66 + #67.

### Changes
- **src/config.py**: new HOSTED_LINK_FRONTEND setting ('legacy' | 'react'), default 'legacy', with validator.
- **src/routers/link_sessions.py**: hosted_link_page() reads the flag at request time and serves frontend-next/dist/index.html when the flag is 'react' and the bundle is present. Falls back to the legacy page with a warning if the bundle is missing.
- **src/app.py**: mounts frontend-next/dist at /ui-next when present.
- **frontend-next/vite.config.ts**: sets base='/ui-next/' to match the mount.

### Tests
- New TestHostedLinkFrontendFlag in tests/test_links.py (5 tests): default legacy, explicit legacy, flag=react with bundle, flag=react missing-bundle fallback, invalid value rejection.
- tests/test_hosted_link_e2e.py (3 tests) still passes against the default (legacy) path, confirming no regression.

### Scope note
The React bundle shipped in #67 is a minimal shell matching the E2E DOM contract; it does **not** yet drive institution search, credential submission, or MFA polling against the API. Running the E2E with HOSTED_LINK_FRONTEND=react would therefore fail at the search step. Feature parity lands in a dedicated follow-up (tracked separately) before #65 flips the default.

### Follow-up
- Full API wiring in frontend-next so the E2E passes with HOSTED_LINK_FRONTEND=react
- #65 flip the default and retire frontend/link.html