### PR TITLE
feat(frontend-next): full hosted-link API parity (#72)

### DIFF
--- a/frontend-next/src/App.test.tsx
+++ b/frontend-next/src/App.test.tsx
@@ -1,60 +1,81 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderToString } from "react-dom/server";
 
 import { App } from "./App";
 import { initialFlowState, type Institution } from "./state";
+import type { Organization } from "./api";
 
-const hydro: Institution = { site: "hydro_one", name: "Hydro One" };
+const hydro: Organization = {
+  organization_id: "org-hydro",
+  site: "hydro_one",
+  name: "Hydro One",
+};
+const institutionHydro: Institution = {
+  site: "hydro_one",
+  name: "Hydro One",
+};
 
-describe("App", () => {
-  it("renders the institution picker with the E2E-required DOM ids", () => {
-    const html = renderToString(<App institutions={[hydro]} />);
+describe("App (SSR smoke)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
+  it("renders the picker with a seeded organization list", () => {
+    const html = renderToString(
+      <App
+        seedInstitutions={[hydro]}
+        apiFactory={() =>
+          ({ getStatus: async () => ({ status: "pending" }) } as unknown as ReturnType<
+            NonNullable<Parameters<typeof App>[0]>["apiFactory"] & object
+          >)
+        }
+        buildEventDelivery={() => null}
+      />,
+    );
     expect(html).toContain('id="step-select"');
     expect(html).toContain('class="link-step active"');
     expect(html).toContain('id="institution-search"');
     expect(html).toContain('class="institution-item"');
     expect(html).toContain("Hydro One");
+    expect(html).toContain('id="consent-list"');
+    expect(html).toContain(
+      "Return a secure completion back to your app when verification finishes.",
+    );
   });
 
-  it("renders the credentials step structure when pre-seeded", () => {
+  it("renders the credentials step with the selected provider", () => {
     const html = renderToString(
       <App
-        institutions={[hydro]}
-        initialState={{
-          ...initialFlowState,
-          step: "credentials",
-          institution: hydro,
-        }}
+        initialState={{ ...initialFlowState, step: "credentials", institution: institutionHydro }}
+        buildEventDelivery={() => null}
       />,
     );
-
     expect(html).toContain('id="step-credentials"');
-    expect(html).toContain('class="link-step active"');
     expect(html).toContain('id="provider-name"');
     expect(html).toContain("Hydro One");
     expect(html).toContain('id="link-username"');
     expect(html).toContain('id="link-password"');
     expect(html).toContain('id="connect-btn"');
-    expect(html).toContain('id="consent-list"');
   });
 
-  it("renders the success step structure when pre-seeded", () => {
+  it("renders the success step with the PUBLIC TOKEN reference", () => {
     const html = renderToString(
       <App
         initialState={{
           ...initialFlowState,
           step: "success",
-          success: { accessToken: "tok_live_abc", summary: "Account linked." },
+          success: {
+            accessToken: "public-abc123",
+            summary: "Your secure connection is complete. Return to your app to finish setup.",
+          },
         }}
+        buildEventDelivery={() => null}
       />,
     );
-
     expect(html).toContain('id="step-success"');
     expect(html).toContain('class="link-step active"');
-    expect(html).toContain('id="success-message"');
-    expect(html).toContain("Account linked.");
-    expect(html).toContain('id="access-token-display"');
-    expect(html).toContain("tok_live_abc");
+    expect(html).toContain("PUBLIC TOKEN");
+    expect(html).toContain("public-abc123");
+    expect(html).toContain("Return to your app");
   });
 });

--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -1,5 +1,23 @@
-import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from "react";
 
+import {
+  encryptCredentials as defaultEncryptCredentials,
+  LinkApi,
+  pollLinkSession as defaultPollLinkSession,
+  type ConnectResponse,
+  type LinkSessionStatus,
+  type Organization,
+  type PollOptions,
+} from "./api";
+import { detectNativeBridges, readHostedLinkConfig } from "./config";
+import { EventDelivery, postBridgeEvent } from "./events";
 import {
   flowReducer,
   initialFlowState,
@@ -7,25 +25,38 @@ import {
   type Institution,
 } from "./state";
 
-/**
- * Minimal hosted-link React shell that matches the DOM contract the
- * Playwright E2E suite (tests/test_hosted_link_e2e.py) depends on:
- *
- *   - #step-select.active with #institution-search + .institution-item
- *   - #step-credentials.active with #provider-name, #consent-list,
- *     #link-username, #link-password, #connect-btn
- *   - #step-success.active with #success-message + #access-token-display
- *
- * The real search, MFA, and API wiring land in #68 when FastAPI starts
- * serving this bundle behind HOSTED_LINK_FRONTEND=react. Until then
- * this component is intentionally self-contained and safe to build.
- */
+const CONSENT_BULLETS: readonly string[] = [
+  "Open a secure browser session with the provider you choose.",
+  "Encrypt your sign-in details before they leave this window.",
+  "Return a secure completion back to your app when verification finishes.",
+];
+
+const SUCCESS_MESSAGE =
+  "Your secure connection is complete. Return to your app to finish setup.";
+
+type EncryptCredentialsFn = typeof defaultEncryptCredentials;
+type PollLinkSessionFn = (options: PollOptions) => Promise<LinkSessionStatus>;
+
+interface ApiFactoryOptions {
+  readonly serverUrl: string;
+  readonly linkToken: string;
+}
 
 export interface AppProps {
-  /** Optional seed institutions; defaults to none (caller fetches later). */
-  readonly institutions?: readonly Institution[];
-  /** Seed state — useful for tests. */
+  /** Seed state — used by unit tests. */
   readonly initialState?: FlowState;
+  /** Overrides the default LinkApi (tests / storybook). */
+  readonly apiFactory?: (options: ApiFactoryOptions) => LinkApi;
+  /** Overrides the RSA-OAEP encryption helper (tests). */
+  readonly encryptCredentials?: EncryptCredentialsFn;
+  /** Overrides the status poller (tests). */
+  readonly pollLinkSession?: PollLinkSessionFn;
+  /** Overrides EventDelivery construction (tests). */
+  readonly buildEventDelivery?: (
+    options: { linkToken: string; serverUrl: string },
+  ) => EventDelivery | null;
+  /** Default institution list (used before the first search completes). */
+  readonly seedInstitutions?: readonly Organization[];
 }
 
 export function App(props: AppProps = {}) {
@@ -33,39 +64,307 @@ export function App(props: AppProps = {}) {
   const [query, setQuery] = useState("");
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [mfaCode, setMfaCode] = useState("");
+  const [organizations, setOrganizations] = useState<readonly Organization[]>(
+    props.seedInstitutions ?? [],
+  );
+  const [searchError, setSearchError] = useState<string | null>(null);
 
-  const institutions = useMemo(() => props.institutions ?? [], [props.institutions]);
+  const configRef = useRef(
+    readHostedLinkConfig(
+      typeof window !== "undefined"
+        ? window.location
+        : ({ search: "", origin: "" } as Location),
+      {
+        referrer: typeof document !== "undefined" ? document.referrer : "",
+        inIframe:
+          typeof window !== "undefined" ? window.parent !== window : false,
+      },
+    ),
+  );
 
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) {
-      return institutions;
-    }
-    return institutions.filter((item) => item.name.toLowerCase().includes(q));
-  }, [institutions, query]);
+  const apiRef = useRef<LinkApi | null>(null);
+  const deliveryRef = useRef<EventDelivery | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const siteRef = useRef<string | null>(null);
 
+  const encryptFn = props.encryptCredentials ?? defaultEncryptCredentials;
+  const pollFn = props.pollLinkSession ?? defaultPollLinkSession;
+
+  // Build the API client + event delivery once per linkToken.
+  if (apiRef.current === null && configRef.current.linkToken) {
+    const factory = props.apiFactory ?? ((opts) => new LinkApi(opts));
+    apiRef.current = factory({
+      serverUrl: configRef.current.serverUrl,
+      linkToken: configRef.current.linkToken,
+    });
+    const buildDelivery =
+      props.buildEventDelivery ??
+      ((opts) => new EventDelivery(opts));
+    deliveryRef.current = buildDelivery({
+      linkToken: configRef.current.linkToken,
+      serverUrl: configRef.current.serverUrl,
+    });
+  }
+
+  const emit = useCallback(
+    (event: string, payload: Record<string, unknown> = {}) => {
+      const cfg = configRef.current;
+      const bridges =
+        typeof globalThis !== "undefined"
+          ? detectNativeBridges(globalThis)
+          : { reactNative: null, webkit: null };
+      postBridgeEvent(event, payload, {
+        parentOrigin: cfg.parentOrigin,
+        inIframe: cfg.inIframe,
+        targetWindow:
+          typeof window !== "undefined" && cfg.inIframe ? window.parent : null,
+        reactNativeBridge: bridges.reactNative,
+        webkitBridge: bridges.webkit,
+      });
+      deliveryRef.current?.enqueue(event, payload);
+    },
+    [],
+  );
+
+  // Validate the session token and announce OPEN on mount.
   useEffect(() => {
-    if (state.step !== "credentials") {
-      setUsername("");
-      setPassword("");
+    const api = apiRef.current;
+    if (!api) {
+      return;
     }
-  }, [state.step]);
+    let cancelled = false;
+    emit("OPEN", {});
+    api
+      .getStatus()
+      .then((status) => {
+        if (cancelled) return;
+        if (status.status === "expired" || status.status === "completed") {
+          dispatch({
+            type: "FAIL",
+            payload: {
+              message: `This link has ${status.status}. Request a fresh link to continue.`,
+            },
+          });
+          return;
+        }
+        if (status.site) {
+          siteRef.current = status.site;
+        }
+      })
+      .catch((err: Error) => {
+        if (cancelled) return;
+        dispatch({
+          type: "FAIL",
+          payload: { message: err.message || "This link is invalid or has expired." },
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [emit]);
 
-  const onSelect = useCallback((institution: Institution) => {
-    dispatch({ type: "SELECT_INSTITUTION", institution });
-  }, []);
+  // Debounced organization search tied to the query input.
+  useEffect(() => {
+    const api = apiRef.current;
+    if (!api) {
+      return;
+    }
+    const handle = globalThis.setTimeout(async () => {
+      try {
+        const payload = await api.searchOrganizations({ query, limit: 40 });
+        setOrganizations(payload.results);
+        setSearchError(null);
+      } catch (err) {
+        setSearchError((err as Error).message || "Could not load providers.");
+      }
+    }, 180);
+    return () => globalThis.clearTimeout(handle);
+  }, [query]);
+
+  // Emit EXIT on unmount so the server can reconcile abandoned sessions.
+  useEffect(() => {
+    return () => {
+      emit("EXIT", { reason: "unmount" });
+      deliveryRef.current?.dispose();
+    };
+  }, [emit]);
+
+  const onSelectInstitution = useCallback(
+    (organization: Organization) => {
+      const institution: Institution = {
+        site: organization.site,
+        name: organization.name,
+        category: organization.category_label,
+        country: organization.country_code,
+      };
+      siteRef.current = organization.site;
+      dispatch({ type: "SELECT_INSTITUTION", institution });
+      emit("INSTITUTION_SELECTED", {
+        organization_id: organization.organization_id,
+        organization_name: organization.name,
+        site: organization.site,
+      });
+    },
+    [emit],
+  );
+
+  const runConnect = useCallback(
+    async (credsUsername: string, credsPassword: string) => {
+      const api = apiRef.current;
+      if (!api) {
+        dispatch({
+          type: "FAIL",
+          payload: { message: "Session is not initialized." },
+        });
+        return;
+      }
+      const site = siteRef.current;
+      if (!site) {
+        dispatch({
+          type: "FAIL",
+          payload: { message: "Choose a provider before continuing." },
+        });
+        return;
+      }
+      dispatch({ type: "SUBMIT_CREDENTIALS" });
+      try {
+        const keyPayload = await api.getEncryptionPublicKey();
+        if (!keyPayload.public_key) {
+          throw new Error("Unable to establish an encrypted session.");
+        }
+        const encrypted = await encryptFn(
+          keyPayload.public_key,
+          credsUsername,
+          credsPassword,
+        );
+        const response = await api.connect({ site, encrypted });
+        await handleConnectResponse(api, response);
+      } catch (err) {
+        const message = (err as Error).message || "Connection failed.";
+        dispatch({ type: "FAIL", payload: { message } });
+        emit("ERROR", { error: message, site });
+      }
+    },
+    [emit, encryptFn],
+  );
+
+  const handleConnectResponse = useCallback(
+    async (api: LinkApi, response: ConnectResponse) => {
+      if (response.session_id) {
+        sessionIdRef.current = response.session_id;
+      }
+      if (response.status === "connected") {
+        await finishSuccess(api, response);
+        return;
+      }
+      if (response.status === "mfa_required") {
+        const message =
+          (response.metadata as { message?: string } | null)?.message ??
+          "Enter the verification code from your provider to continue.";
+        dispatch({ type: "MFA_REQUIRED", prompt: message });
+        emit("MFA_REQUIRED", {
+          mfa_type: response.mfa_type ?? "otp",
+          session_id: response.session_id ?? null,
+        });
+        return;
+      }
+      if (response.status === "pending") {
+        const terminal = await pollFn({ api });
+        if (terminal.status === "completed") {
+          await finishSuccess(api, terminal);
+          return;
+        }
+        if (terminal.status === "mfa_required") {
+          dispatch({
+            type: "MFA_REQUIRED",
+            prompt:
+              terminal.message ||
+              "Enter the verification code from your provider to continue.",
+          });
+          emit("MFA_REQUIRED", {
+            mfa_type: terminal.mfa_type ?? "otp",
+            session_id: terminal.session_id ?? null,
+          });
+          return;
+        }
+        const message =
+          terminal.error_message ||
+          terminal.message ||
+          (terminal.status === "timeout"
+            ? "The connection timed out before the provider completed the flow."
+            : "The connection could not be completed.");
+        dispatch({ type: "FAIL", payload: { message } });
+        emit("ERROR", { error: message, site: siteRef.current });
+        return;
+      }
+      const message =
+        response.error || response.detail || `Unexpected status: ${response.status}`;
+      dispatch({ type: "FAIL", payload: { message } });
+      emit("ERROR", { error: message, site: siteRef.current });
+    },
+    [emit, pollFn],
+  );
+
+  const finishSuccess = useCallback(
+    async (api: LinkApi, payload: ConnectResponse | LinkSessionStatus) => {
+      // /connect may not include public_token on the first response; the
+      // backend stores it on the session and surfaces it through the
+      // status endpoint, matching the legacy page's resolveHostedSuccess.
+      let resolved: ConnectResponse | LinkSessionStatus = payload;
+      if (!resolved.public_token) {
+        try {
+          const status = await api.getStatus();
+          if (status.status === "completed" && status.public_token) {
+            resolved = status;
+          }
+        } catch {
+          // Fall back to whatever we already have.
+        }
+      }
+      const publicToken = resolved.public_token ?? "";
+      dispatch({
+        type: "SUCCEED",
+        payload: { accessToken: publicToken, summary: SUCCESS_MESSAGE },
+      });
+      emit("CONNECTED", {
+        job_id: resolved.job_id ?? null,
+        public_token: publicToken,
+        site: siteRef.current,
+      });
+    },
+    [emit],
+  );
 
   const onSubmitCredentials = useCallback(() => {
-    dispatch({ type: "SUBMIT_CREDENTIALS" });
-  }, []);
+    void runConnect(username, password);
+  }, [password, runConnect, username]);
 
-  // username/password are tracked for the form; actual transmission
-  // lands in #68 when the API client is wired in.
-  void username;
-  void password;
+  const onSubmitMfa = useCallback(async () => {
+    const api = apiRef.current;
+    const sessionId = sessionIdRef.current;
+    if (!api || !sessionId || !mfaCode.trim()) {
+      return;
+    }
+    dispatch({ type: "SUBMIT_MFA" });
+    emit("MFA_SUBMITTED", { session_id: sessionId });
+    try {
+      const response = await api.submitMfa({
+        sessionId,
+        code: mfaCode.trim(),
+      });
+      await handleConnectResponse(api, response);
+    } catch (err) {
+      const message = (err as Error).message || "Verification failed.";
+      dispatch({ type: "FAIL", payload: { message } });
+      emit("ERROR", { error: message, site: siteRef.current });
+    }
+  }, [emit, handleConnectResponse, mfaCode]);
+
+  const consent = useMemo(() => CONSENT_BULLETS, []);
 
   return (
-    <main role="main" aria-label="Plaidify Link">
+    <main role="main" aria-label="Plaidify Link" className="plaidify-link">
       <section
         id="step-select"
         className={state.step === "select" ? "link-step active" : "link-step"}
@@ -83,22 +382,27 @@ export function App(props: AppProps = {}) {
           placeholder="Search providers"
           autoComplete="off"
         />
+        {searchError ? (
+          <p className="search-error" role="alert">
+            {searchError}
+          </p>
+        ) : null}
         <ul id="institution-list" aria-label="Matching providers">
-          {filtered.map((institution) => (
+          {organizations.map((organization) => (
             <li
-              key={institution.site}
+              key={organization.organization_id || organization.site}
               className="institution-item"
               role="button"
               tabIndex={0}
-              onClick={() => onSelect(institution)}
+              onClick={() => onSelectInstitution(organization)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
                   e.preventDefault();
-                  onSelect(institution);
+                  onSelectInstitution(organization);
                 }
               }}
             >
-              {institution.name}
+              {organization.name}
             </li>
           ))}
         </ul>
@@ -112,9 +416,9 @@ export function App(props: AppProps = {}) {
       >
         <h2 id="provider-name">{state.institution?.name ?? ""}</h2>
         <ul id="consent-list">
-          <li>Plaidify opens a secure session with your provider.</li>
-          <li>Your sign-in details are encrypted before submission.</li>
-          <li>Only the selected provider receives your encrypted credentials.</li>
+          {consent.map((item) => (
+            <li key={item}>{item}</li>
+          ))}
         </ul>
         <label htmlFor="link-username">Username</label>
         <input
@@ -133,7 +437,37 @@ export function App(props: AppProps = {}) {
           onChange={(e) => setPassword(e.target.value)}
         />
         <button id="connect-btn" type="button" onClick={onSubmitCredentials}>
-          Connect
+          Continue
+        </button>
+      </section>
+
+      <section
+        id="step-connecting"
+        className={state.step === "connecting" ? "link-step active" : "link-step"}
+        role="region"
+        aria-label="Connecting"
+      >
+        <p>Creating your secure session&hellip;</p>
+      </section>
+
+      <section
+        id="step-mfa"
+        className={state.step === "mfa" ? "link-step active" : "link-step"}
+        role="region"
+        aria-label="Finish verification"
+      >
+        <p id="mfa-message">{state.mfaPrompt ?? ""}</p>
+        <label htmlFor="mfa-code">Verification code</label>
+        <input
+          id="mfa-code"
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          value={mfaCode}
+          onChange={(e) => setMfaCode(e.target.value)}
+        />
+        <button id="mfa-submit-btn" type="button" onClick={() => void onSubmitMfa()}>
+          Verify and continue
         </button>
       </section>
 
@@ -143,8 +477,31 @@ export function App(props: AppProps = {}) {
         role="region"
         aria-label="Connection successful"
       >
-        <p id="success-message">{state.success?.summary ?? "Connected."}</p>
-        <code id="access-token-display">{state.success?.accessToken ?? ""}</code>
+        <p id="success-message">{state.success?.summary ?? SUCCESS_MESSAGE}</p>
+        <div id="access-token-display">
+          {state.success?.accessToken ? (
+            <div className="reference-row">
+              <span className="reference-label">PUBLIC TOKEN</span>
+              <span className="reference-value">{state.success.accessToken}</span>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section
+        id="step-error"
+        className={state.step === "error" ? "link-step active" : "link-step"}
+        role="region"
+        aria-label="Connection failed"
+      >
+        <p id="error-message">{state.error?.message ?? ""}</p>
+        <button
+          id="retry-btn"
+          type="button"
+          onClick={() => dispatch({ type: "BACK_TO_PICKER" })}
+        >
+          Try again
+        </button>
       </section>
     </main>
   );

--- a/frontend-next/src/api.test.ts
+++ b/frontend-next/src/api.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  ApiError,
+  LinkApi,
+  encryptCredentials,
+  pollLinkSession,
+} from "./api";
+
+function okResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("LinkApi", () => {
+  it("encodes the link token in the status URL", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okResponse({ status: "pending" }));
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test/",
+      linkToken: "tok with space",
+      fetchImpl,
+    });
+    const status = await api.getStatus();
+
+    expect(status.status).toBe("pending");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.plaidify.test/link/sessions/tok%20with%20space/status",
+    );
+  });
+
+  it("builds the organization search URL", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okResponse({ results: [], count: 0 }));
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test",
+      linkToken: "tok",
+      fetchImpl,
+    });
+    await api.searchOrganizations({ query: "hydro", limit: 5 });
+
+    const [url] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.plaidify.test/organizations/search?q=hydro&limit=5",
+    );
+  });
+
+  it("serializes the /connect body", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okResponse({ status: "connected", public_token: "public-1" }));
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test",
+      linkToken: "tok",
+      fetchImpl,
+    });
+    const response = await api.connect({
+      site: "hydro_one",
+      encrypted: { username: "u", password: "p" },
+    });
+
+    expect(response.status).toBe("connected");
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.plaidify.test/connect");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toEqual({
+      link_token: "tok",
+      site: "hydro_one",
+      encrypted_username: "u",
+      encrypted_password: "p",
+    });
+  });
+
+  it("raises ApiError with the server detail on non-2xx", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(async () =>
+      new Response(JSON.stringify({ detail: "bad token" }), {
+        status: 403,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test",
+      linkToken: "tok",
+      fetchImpl,
+    });
+
+    let caught: unknown;
+    try {
+      await api.getStatus();
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ApiError);
+    expect((caught as ApiError).status).toBe(403);
+    expect((caught as ApiError).message).toBe("bad token");
+  });
+
+  it("builds the /mfa/submit URL with query params", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValue(okResponse({ status: "connected" }));
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test",
+      linkToken: "tok",
+      fetchImpl,
+    });
+    await api.submitMfa({ sessionId: "sess-1", code: "123 456" });
+
+    const [url, init] = fetchImpl.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "https://api.plaidify.test/mfa/submit?session_id=sess-1&code=123+456",
+    );
+    expect(init.method).toBe("POST");
+  });
+});
+
+describe("encryptCredentials", () => {
+  it("encrypts username and password separately and base64-encodes them", async () => {
+    const importKey = vi.fn().mockResolvedValue({ fake: true });
+    const encrypt = vi
+      .fn()
+      .mockImplementationOnce(async () => new Uint8Array([1, 2, 3]).buffer)
+      .mockImplementationOnce(async () => new Uint8Array([4, 5, 6]).buffer);
+
+    const subtle = { importKey, encrypt } as unknown as SubtleCrypto;
+    const pem = `-----BEGIN PUBLIC KEY-----\nQUJD\n-----END PUBLIC KEY-----`;
+
+    const result = await encryptCredentials(pem, "user", "pass", subtle);
+
+    expect(importKey).toHaveBeenCalledTimes(1);
+    const [format, _buffer, algorithm] = importKey.mock.calls[0];
+    expect(format).toBe("spki");
+    expect(algorithm).toEqual({ name: "RSA-OAEP", hash: "SHA-256" });
+    expect(encrypt).toHaveBeenCalledTimes(2);
+    expect(result.username).toBe(btoa(String.fromCharCode(1, 2, 3)));
+    expect(result.password).toBe(btoa(String.fromCharCode(4, 5, 6)));
+  });
+});
+
+describe("pollLinkSession", () => {
+  it("returns immediately on a terminal status", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () =>
+        okResponse({ status: "completed", public_token: "public-1" }),
+      );
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test",
+      linkToken: "tok",
+      fetchImpl,
+    });
+    const result = await pollLinkSession({ api, sleep: async () => undefined });
+    expect(result.status).toBe("completed");
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls until the status leaves the pending state", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(okResponse({ status: "pending" }))
+      .mockResolvedValueOnce(okResponse({ status: "pending" }))
+      .mockResolvedValueOnce(okResponse({ status: "completed", public_token: "public-x" }));
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test",
+      linkToken: "tok",
+      fetchImpl,
+    });
+    const ticks: string[] = [];
+    const result = await pollLinkSession({
+      api,
+      sleep: async () => undefined,
+      onTick: (status) => ticks.push(status.status),
+    });
+    expect(result.status).toBe("completed");
+    expect(ticks).toEqual(["pending", "pending", "completed"]);
+  });
+
+  it("returns a timeout status after the max attempts", async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockImplementation(async () => okResponse({ status: "pending" }));
+
+    const api = new LinkApi({
+      serverUrl: "https://api.plaidify.test",
+      linkToken: "tok",
+      fetchImpl,
+    });
+    const result = await pollLinkSession({
+      api,
+      maxAttempts: 3,
+      sleep: async () => undefined,
+    });
+    expect(result.status).toBe("timeout");
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+});

--- a/frontend-next/src/api.ts
+++ b/frontend-next/src/api.ts
@@ -1,0 +1,281 @@
+/**
+ * Typed API client for the Plaidify hosted-link flow.
+ *
+ * The legacy vanilla-JS page hit a handful of endpoints through an
+ * untyped `apiCall` helper. This module narrows the types and keeps
+ * every network call in one place so the React shell in App.tsx reads
+ * as pure UI + dispatch.
+ */
+
+export interface LinkSessionStatus {
+  readonly status: string;
+  readonly job_id?: string | null;
+  readonly session_id?: string | null;
+  readonly site?: string | null;
+  readonly public_token?: string | null;
+  readonly metadata?: Record<string, unknown> | null;
+  readonly mfa_type?: string | null;
+  readonly message?: string | null;
+  readonly error_message?: string | null;
+}
+
+export interface Organization {
+  readonly organization_id: string;
+  readonly name: string;
+  readonly site: string;
+  readonly country_code?: string;
+  readonly region_code?: string;
+  readonly category_label?: string;
+  readonly service_area?: string;
+  readonly has_mfa?: boolean;
+}
+
+export interface OrganizationSearchResponse {
+  readonly results: readonly Organization[];
+  readonly count?: number;
+  readonly summary?: {
+    readonly total_count?: number;
+    readonly countries?: readonly { code: string; label: string; count: number }[];
+    readonly categories?: readonly { key: string; label: string; count: number }[];
+  } | null;
+}
+
+export interface EncryptionPublicKeyResponse {
+  readonly public_key: string;
+}
+
+export interface ConnectResponse {
+  readonly status: "connected" | "mfa_required" | "pending" | "error" | string;
+  readonly job_id?: string | null;
+  readonly session_id?: string | null;
+  readonly public_token?: string | null;
+  readonly mfa_type?: string | null;
+  readonly error?: string | null;
+  readonly detail?: string | null;
+  readonly metadata?: Record<string, unknown> | null;
+}
+
+export interface EncryptedCredentials {
+  readonly username: string;
+  readonly password: string;
+}
+
+export class ApiError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+function joinUrl(base: string, path: string): string {
+  return `${base.replace(/\/$/, "")}${path}`;
+}
+
+async function request<T>(
+  fetchImpl: typeof fetch,
+  method: string,
+  url: string,
+  body?: unknown,
+): Promise<T> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  const init: RequestInit = { method, headers };
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+  const response = await fetchImpl(url, init);
+  const text = await response.text();
+  const payload = text ? (JSON.parse(text) as unknown) : ({} as unknown);
+  if (!response.ok) {
+    const record = payload as { detail?: string; error?: string };
+    const message =
+      record.detail || record.error || response.statusText || "Request failed";
+    throw new ApiError(message, response.status);
+  }
+  return payload as T;
+}
+
+export interface LinkApiOptions {
+  readonly serverUrl: string;
+  readonly linkToken: string;
+  readonly fetchImpl?: typeof fetch;
+}
+
+export class LinkApi {
+  private readonly fetchImpl: typeof fetch;
+  private readonly serverUrl: string;
+  private readonly linkToken: string;
+
+  constructor(options: LinkApiOptions) {
+    if (!options.linkToken) {
+      throw new Error("LinkApi requires a linkToken.");
+    }
+    if (!options.serverUrl) {
+      throw new Error("LinkApi requires a serverUrl.");
+    }
+    this.serverUrl = options.serverUrl.replace(/\/$/, "");
+    this.linkToken = options.linkToken;
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  }
+
+  getStatus(): Promise<LinkSessionStatus> {
+    return request<LinkSessionStatus>(
+      this.fetchImpl,
+      "GET",
+      joinUrl(
+        this.serverUrl,
+        `/link/sessions/${encodeURIComponent(this.linkToken)}/status`,
+      ),
+    );
+  }
+
+  searchOrganizations(params: {
+    query?: string;
+    site?: string;
+    limit?: number;
+  }): Promise<OrganizationSearchResponse> {
+    const search = new URLSearchParams();
+    if (params.query) {
+      search.set("q", params.query);
+    }
+    if (params.site) {
+      search.set("site", params.site);
+    }
+    search.set("limit", String(params.limit ?? 40));
+    return request<OrganizationSearchResponse>(
+      this.fetchImpl,
+      "GET",
+      joinUrl(this.serverUrl, `/organizations/search?${search.toString()}`),
+    );
+  }
+
+  getEncryptionPublicKey(): Promise<EncryptionPublicKeyResponse> {
+    return request<EncryptionPublicKeyResponse>(
+      this.fetchImpl,
+      "GET",
+      joinUrl(
+        this.serverUrl,
+        `/encryption/public_key/${encodeURIComponent(this.linkToken)}`,
+      ),
+    );
+  }
+
+  connect(params: {
+    site: string;
+    encrypted: EncryptedCredentials;
+  }): Promise<ConnectResponse> {
+    return request<ConnectResponse>(
+      this.fetchImpl,
+      "POST",
+      joinUrl(this.serverUrl, "/connect"),
+      {
+        link_token: this.linkToken,
+        site: params.site,
+        encrypted_username: params.encrypted.username,
+        encrypted_password: params.encrypted.password,
+      },
+    );
+  }
+
+  submitMfa(params: { sessionId: string; code: string }): Promise<ConnectResponse> {
+    const search = new URLSearchParams({
+      session_id: params.sessionId,
+      code: params.code,
+    });
+    return request<ConnectResponse>(
+      this.fetchImpl,
+      "POST",
+      joinUrl(this.serverUrl, `/mfa/submit?${search.toString()}`),
+    );
+  }
+}
+
+/**
+ * RSA-OAEP credential encryption identical to the legacy hosted-link
+ * page. The server returns a SPKI public key in PEM form; we strip the
+ * header/footer, base64-decode, import via WebCrypto, and encrypt
+ * username + password separately so the backend can store them as
+ * independently-wrapped blobs.
+ */
+export async function encryptCredentials(
+  publicKeyPem: string,
+  username: string,
+  password: string,
+  subtle: SubtleCrypto = globalThis.crypto.subtle,
+): Promise<EncryptedCredentials> {
+  const body = publicKeyPem
+    .replace(/-----BEGIN PUBLIC KEY-----/, "")
+    .replace(/-----END PUBLIC KEY-----/, "")
+    .replace(/\s/g, "");
+  const binary = Uint8Array.from(atob(body), (character) => character.charCodeAt(0));
+  const cryptoKey = await subtle.importKey(
+    "spki",
+    binary.buffer,
+    { name: "RSA-OAEP", hash: "SHA-256" },
+    false,
+    ["encrypt"],
+  );
+
+  const encoder = new TextEncoder();
+  const [encryptedUsername, encryptedPassword] = await Promise.all([
+    subtle.encrypt({ name: "RSA-OAEP" }, cryptoKey, encoder.encode(username)),
+    subtle.encrypt({ name: "RSA-OAEP" }, cryptoKey, encoder.encode(password)),
+  ]);
+
+  return {
+    username: bytesToBase64(new Uint8Array(encryptedUsername)),
+    password: bytesToBase64(new Uint8Array(encryptedPassword)),
+  };
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += 1) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Poll /link/sessions/{token}/status until the session reaches a
+ * terminal state, an MFA prompt, or the timeout. Matches the legacy
+ * page's 90-attempt / 1100 ms cadence so existing backends behave the
+ * same under the React shell.
+ */
+export interface PollOptions {
+  readonly api: LinkApi;
+  readonly maxAttempts?: number;
+  readonly intervalMs?: number;
+  readonly sleep?: (ms: number) => Promise<void>;
+  readonly onTick?: (status: LinkSessionStatus, attempt: number) => void;
+}
+
+const DEFAULT_POLL_MAX = 90;
+const DEFAULT_POLL_INTERVAL_MS = 1100;
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => globalThis.setTimeout(resolve, ms));
+
+export async function pollLinkSession(
+  options: PollOptions,
+): Promise<LinkSessionStatus> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_POLL_MAX;
+  const intervalMs = options.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+  const sleep = options.sleep ?? defaultSleep;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const status = await options.api.getStatus();
+    options.onTick?.(status, attempt);
+
+    if (
+      status.status === "completed" ||
+      status.status === "error" ||
+      status.status === "mfa_required"
+    ) {
+      return status;
+    }
+    await sleep(intervalMs);
+  }
+
+  return { status: "timeout" };
+}

--- a/frontend-next/src/config.test.ts
+++ b/frontend-next/src/config.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import { detectNativeBridges, readHostedLinkConfig } from "./config";
+
+describe("readHostedLinkConfig", () => {
+  it("prefers the explicit ?origin= query parameter", () => {
+    const config = readHostedLinkConfig(
+      { search: "?token=tok&origin=https://merchant.example", origin: "https://host" },
+      { referrer: "", inIframe: true },
+    );
+    expect(config.linkToken).toBe("tok");
+    expect(config.parentOrigin).toBe("https://merchant.example");
+    expect(config.serverUrl).toBe("https://host");
+    expect(config.inIframe).toBe(true);
+  });
+
+  it("derives the parent origin from the referrer when no ?origin= is set", () => {
+    const config = readHostedLinkConfig(
+      { search: "?token=tok", origin: "https://host" },
+      { referrer: "https://app.example/checkout?flow=1", inIframe: true },
+    );
+    expect(config.parentOrigin).toBe("https://app.example");
+  });
+
+  it("falls back to the server URL when embedded with no referrer", () => {
+    const config = readHostedLinkConfig(
+      { search: "?token=tok", origin: "https://host" },
+      { referrer: "", inIframe: true },
+    );
+    expect(config.parentOrigin).toBe("https://host");
+  });
+
+  it("honours an explicit server override", () => {
+    const config = readHostedLinkConfig(
+      { search: "?token=tok&server=https://api.plaidify.test/", origin: "https://host" },
+      { referrer: "", inIframe: false },
+    );
+    expect(config.serverUrl).toBe("https://api.plaidify.test");
+  });
+});
+
+describe("detectNativeBridges", () => {
+  it("picks up React Native WebView handlers", () => {
+    const target = { ReactNativeWebView: { postMessage: () => undefined } } as unknown as typeof globalThis;
+    const bridges = detectNativeBridges(target);
+    expect(bridges.reactNative).not.toBeNull();
+    expect(bridges.webkit).toBeNull();
+  });
+
+  it("picks up WKWebView handlers", () => {
+    const target = {
+      webkit: { messageHandlers: { plaidifyLink: { postMessage: () => undefined } } },
+    } as unknown as typeof globalThis;
+    const bridges = detectNativeBridges(target);
+    expect(bridges.webkit).not.toBeNull();
+    expect(bridges.reactNative).toBeNull();
+  });
+
+  it("returns both null when no bridge is present", () => {
+    const bridges = detectNativeBridges({} as unknown as typeof globalThis);
+    expect(bridges.reactNative).toBeNull();
+    expect(bridges.webkit).toBeNull();
+  });
+});

--- a/frontend-next/src/config.ts
+++ b/frontend-next/src/config.ts
@@ -1,0 +1,89 @@
+/**
+ * Read config from URL query string + runtime globals.
+ *
+ * The hosted-link page is loaded as `/link?token=...&server=...&origin=...`.
+ * We also sniff the parent origin from document.referrer so embedders
+ * don't have to pass it explicitly.
+ */
+export interface HostedLinkConfig {
+  readonly linkToken: string | null;
+  readonly serverUrl: string;
+  readonly parentOrigin: string;
+  readonly inIframe: boolean;
+}
+
+export function readHostedLinkConfig(
+  location: Pick<Location, "search" | "origin">,
+  options: {
+    readonly referrer: string;
+    readonly inIframe: boolean;
+  },
+): HostedLinkConfig {
+  const params = new URLSearchParams(location.search);
+  const linkToken = params.get("token");
+  const serverUrl = (params.get("server") || location.origin).replace(/\/$/, "");
+  const explicitOrigin = params.get("origin");
+
+  let parentOrigin: string;
+  if (explicitOrigin) {
+    parentOrigin = explicitOrigin;
+  } else if (options.referrer) {
+    try {
+      parentOrigin = new URL(options.referrer).origin;
+    } catch {
+      parentOrigin = options.inIframe ? serverUrl : "*";
+    }
+  } else {
+    parentOrigin = options.inIframe ? serverUrl : "*";
+  }
+
+  return {
+    linkToken,
+    serverUrl,
+    parentOrigin,
+    inIframe: options.inIframe,
+  };
+}
+
+export interface ReactNativeBridge {
+  readonly postMessage: (payload: string) => void;
+}
+
+export interface WebkitBridge {
+  readonly postMessage: (payload: Record<string, unknown>) => void;
+}
+
+export interface DetectedBridges {
+  readonly reactNative: ReactNativeBridge | null;
+  readonly webkit: WebkitBridge | null;
+}
+
+export function detectNativeBridges(target: typeof globalThis): DetectedBridges {
+  let reactNative: ReactNativeBridge | null = null;
+  let webkit: WebkitBridge | null = null;
+
+  const rn = (target as unknown as {
+    ReactNativeWebView?: { postMessage?: (payload: string) => void };
+  }).ReactNativeWebView;
+  if (rn && typeof rn.postMessage === "function") {
+    reactNative = { postMessage: rn.postMessage.bind(rn) };
+  }
+
+  const webkitHandlers = (target as unknown as {
+    webkit?: {
+      messageHandlers?: {
+        plaidifyLink?: { postMessage?: (payload: unknown) => void };
+      };
+    };
+  }).webkit?.messageHandlers?.plaidifyLink;
+
+  if (webkitHandlers && typeof webkitHandlers.postMessage === "function") {
+    webkit = {
+      postMessage: webkitHandlers.postMessage.bind(webkitHandlers) as (
+        payload: Record<string, unknown>,
+      ) => void,
+    };
+  }
+
+  return { reactNative, webkit };
+}

--- a/frontend-next/src/events.test.ts
+++ b/frontend-next/src/events.test.ts
@@ -217,8 +217,8 @@ describe("postBridgeEvent", () => {
     );
   });
 
-  it("serializes to a native bridge when present", () => {
-    const nativeBridge = { postMessage: vi.fn() };
+  it("serializes to a React Native bridge when present", () => {
+    const reactNativeBridge = { postMessage: vi.fn() };
 
     postBridgeEvent(
       "EXIT",
@@ -226,15 +226,36 @@ describe("postBridgeEvent", () => {
       {
         parentOrigin: "*",
         inIframe: false,
-        nativeBridge,
+        reactNativeBridge,
       },
     );
 
-    expect(nativeBridge.postMessage).toHaveBeenCalledTimes(1);
-    expect(JSON.parse(nativeBridge.postMessage.mock.calls[0][0])).toEqual({
+    expect(reactNativeBridge.postMessage).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(reactNativeBridge.postMessage.mock.calls[0][0])).toEqual({
       source: "plaidify-link",
       event: "EXIT",
       reason: "user-closed",
+    });
+  });
+
+  it("delivers the raw object to a WKWebView bridge", () => {
+    const webkitBridge = { postMessage: vi.fn() };
+
+    postBridgeEvent(
+      "CONNECTED",
+      { public_token: "public-1" },
+      {
+        parentOrigin: "*",
+        inIframe: false,
+        webkitBridge,
+      },
+    );
+
+    expect(webkitBridge.postMessage).toHaveBeenCalledTimes(1);
+    expect(webkitBridge.postMessage.mock.calls[0][0]).toEqual({
+      source: "plaidify-link",
+      event: "CONNECTED",
+      public_token: "public-1",
     });
   });
 

--- a/frontend-next/src/events.ts
+++ b/frontend-next/src/events.ts
@@ -166,12 +166,20 @@ export class EventDelivery {
 /**
  * Fire-and-forget bridge notification to the parent frame and/or the
  * native webview shell. Matches the message shape the legacy page uses
- * so the Plaidify SDKs (JS, Swift) keep working unchanged.
+ * so the Plaidify SDKs (JS, Swift) keep working unchanged:
+ *   - React Native WebView receives the JSON-serialised string.
+ *   - WKWebView (webkit.messageHandlers.plaidifyLink) receives the
+ *     object directly, which is what the iOS SDK expects.
  */
 export interface ParentBridgeOptions {
   readonly parentOrigin: string;
   readonly inIframe: boolean;
   readonly targetWindow?: Window | null;
+  readonly reactNativeBridge?: { postMessage: (payload: string) => void } | null;
+  readonly webkitBridge?:
+    | { postMessage: (payload: Record<string, unknown>) => void }
+    | null;
+  /** Legacy alias retained for tests that pre-date the split bridges. */
   readonly nativeBridge?: { postMessage: (payload: string) => void } | null;
 }
 
@@ -191,9 +199,18 @@ export function postBridgeEvent(
     }
   }
 
-  if (options.nativeBridge) {
+  const rn = options.reactNativeBridge ?? options.nativeBridge ?? null;
+  if (rn) {
     try {
-      options.nativeBridge.postMessage(JSON.stringify(message));
+      rn.postMessage(JSON.stringify(message));
+    } catch {
+      // Same rationale as above.
+    }
+  }
+
+  if (options.webkitBridge) {
+    try {
+      options.webkitBridge.postMessage(message);
     } catch {
       // Same rationale as above.
     }


### PR DESCRIPTION
Closes #72. Prerequisite to #65 (flipping the default to the React bundle).

## What
- Typed `LinkApi` client + `ApiError` covering every hosted-link endpoint.
- `encryptCredentials` (RSA-OAEP via WebCrypto) and `pollLinkSession` terminal-status helper.
- `readHostedLinkConfig` + `detectNativeBridges` — splits the native-bridge surface into ReactNative (JSON string) and WKWebView (raw object) targets to match the legacy contract.
- `postBridgeEvent` updated to deliver each target its expected payload shape.
- Full `App.tsx` rewrite: mount OPEN, debounced institution search, encrypt+connect, MFA round-trip, pending polling, success resolved via `getStatus` to populate `public_token`, sanitized `CONNECTED` bridge payload (no `access_token`, no `data`).

## Tests
- 34 Vitest unit tests pass (`state`, `events`, `api`, `config`, `App` SSR).
- Playwright E2E (`tests/test_hosted_link_e2e.py`) passes under `HOSTED_LINK_FRONTEND=react` *and* the legacy default (3 tests each).
- `tests/test_links.py` flag gating tests still green (5).

## Follow-up
- #65 can now flip the default to `react` and retire the legacy page.