### PR TITLE
feat(#53): per-institution branding metadata + branded hosted-link picker

### DIFF
--- a/frontend-next/src/App.test.tsx
+++ b/frontend-next/src/App.test.tsx
@@ -9,10 +9,20 @@ const hydro: Organization = {
   organization_id: "org-hydro",
   site: "hydro_one",
   name: "Hydro One",
+  logo_url: "data:image/svg+xml;base64,PHN2Zy8+",
+  logo_monogram: "HO",
+  primary_color: "#1f6f43",
+  secondary_color: "#e7f4ec",
+  accent_color: "#f2c14e",
+  hint_copy: "Use your utility portal sign-in.",
+  auth_style: "email_password",
 };
 const institutionHydro: Institution = {
   site: "hydro_one",
   name: "Hydro One",
+  primary_color: "#1f6f43",
+  hint_copy: "Use your utility portal sign-in.",
+  auth_style: "email_password",
 };
 
 describe("App (SSR smoke)", () => {
@@ -37,6 +47,8 @@ describe("App (SSR smoke)", () => {
     expect(html).toContain('id="institution-search"');
     expect(html).toContain('class="institution-item"');
     expect(html).toContain("Hydro One");
+    expect(html).toContain('data-organization-id="org-hydro"');
+    expect(html).toContain('src="data:image/svg+xml;base64,PHN2Zy8+"');
     expect(html).toContain('id="consent-list"');
     expect(html).toContain(
       "Return a secure completion back to your app when verification finishes.",
@@ -53,6 +65,9 @@ describe("App (SSR smoke)", () => {
     expect(html).toContain('id="step-credentials"');
     expect(html).toContain('id="provider-name"');
     expect(html).toContain("Hydro One");
+    expect(html).toContain('id="provider-hint"');
+    expect(html).toContain("Use your utility portal sign-in.");
+    expect(html).toContain(">Email<");
     expect(html).toContain('id="link-username"');
     expect(html).toContain('id="link-password"');
     expect(html).toContain('id="connect-btn"');

--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -197,6 +197,12 @@ export function App(props: AppProps = {}) {
         name: organization.name,
         category: organization.category_label,
         country: organization.country_code,
+        logo_url: organization.logo_url,
+        primary_color: organization.primary_color,
+        secondary_color: organization.secondary_color,
+        accent_color: organization.accent_color,
+        hint_copy: organization.hint_copy,
+        auth_style: organization.auth_style,
       };
       siteRef.current = organization.site;
       dispatch({ type: "SELECT_INSTITUTION", institution });
@@ -394,6 +400,16 @@ export function App(props: AppProps = {}) {
               className="institution-item"
               role="button"
               tabIndex={0}
+              data-organization-id={organization.organization_id}
+              style={
+                organization.primary_color
+                  ? ({
+                      "--organization-primary": organization.primary_color,
+                      "--organization-secondary":
+                        organization.secondary_color ?? "transparent",
+                    } as React.CSSProperties)
+                  : undefined
+              }
               onClick={() => onSelectInstitution(organization)}
               onKeyDown={(e) => {
                 if (e.key === "Enter" || e.key === " ") {
@@ -402,7 +418,37 @@ export function App(props: AppProps = {}) {
                 }
               }}
             >
-              {organization.name}
+              {organization.logo_url ? (
+                <img
+                  className="institution-item__logo"
+                  src={organization.logo_url}
+                  alt=""
+                  width={32}
+                  height={32}
+                  aria-hidden="true"
+                />
+              ) : (
+                <span
+                  className="institution-item__monogram"
+                  aria-hidden="true"
+                  style={
+                    organization.primary_color
+                      ? {
+                          background: organization.primary_color,
+                          color: organization.secondary_color ?? "#fff",
+                        }
+                      : undefined
+                  }
+                >
+                  {organization.logo_monogram ?? organization.name.slice(0, 1)}
+                </span>
+              )}
+              <span className="institution-item__name">{organization.name}</span>
+              {organization.category_label ? (
+                <span className="institution-item__category">
+                  {organization.category_label}
+                </span>
+              ) : null}
             </li>
           ))}
         </ul>
@@ -413,18 +459,57 @@ export function App(props: AppProps = {}) {
         className={state.step === "credentials" ? "link-step active" : "link-step"}
         role="region"
         aria-label="Enter your credentials"
+        style={
+          state.institution?.primary_color
+            ? ({
+                "--organization-primary": state.institution.primary_color,
+                "--organization-secondary":
+                  state.institution.secondary_color ?? "transparent",
+                "--organization-accent":
+                  state.institution.accent_color ?? state.institution.primary_color,
+              } as React.CSSProperties)
+            : undefined
+        }
       >
-        <h2 id="provider-name">{state.institution?.name ?? ""}</h2>
+        <header className="credentials-header">
+          {state.institution?.logo_url ? (
+            <img
+              className="credentials-header__logo"
+              src={state.institution.logo_url}
+              alt=""
+              width={48}
+              height={48}
+              aria-hidden="true"
+            />
+          ) : null}
+          <h2 id="provider-name">{state.institution?.name ?? ""}</h2>
+        </header>
+        {state.institution?.hint_copy ? (
+          <p id="provider-hint" className="credentials-hint">
+            {state.institution.hint_copy}
+          </p>
+        ) : null}
         <ul id="consent-list">
           {consent.map((item) => (
             <li key={item}>{item}</li>
           ))}
         </ul>
-        <label htmlFor="link-username">Username</label>
+        <label htmlFor="link-username">
+          {state.institution?.auth_style === "email_password"
+            ? "Email"
+            : state.institution?.auth_style === "member_number"
+              ? "Member number"
+              : "Username"}
+        </label>
         <input
           id="link-username"
-          type="text"
-          autoComplete="username"
+          type={state.institution?.auth_style === "email_password" ? "email" : "text"}
+          autoComplete={
+            state.institution?.auth_style === "email_password" ? "email" : "username"
+          }
+          inputMode={
+            state.institution?.auth_style === "member_number" ? "numeric" : undefined
+          }
           value={username}
           onChange={(e) => setUsername(e.target.value)}
         />

--- a/frontend-next/src/api.ts
+++ b/frontend-next/src/api.ts
@@ -19,6 +19,11 @@ export interface LinkSessionStatus {
   readonly error_message?: string | null;
 }
 
+export type OrganizationAuthStyle =
+  | "username_password"
+  | "email_password"
+  | "member_number";
+
 export interface Organization {
   readonly organization_id: string;
   readonly name: string;
@@ -28,6 +33,13 @@ export interface Organization {
   readonly category_label?: string;
   readonly service_area?: string;
   readonly has_mfa?: boolean;
+  readonly logo_url?: string;
+  readonly logo_monogram?: string;
+  readonly primary_color?: string;
+  readonly secondary_color?: string;
+  readonly accent_color?: string;
+  readonly hint_copy?: string;
+  readonly auth_style?: OrganizationAuthStyle;
 }
 
 export interface OrganizationSearchResponse {

--- a/frontend-next/src/link.css
+++ b/frontend-next/src/link.css
@@ -1,0 +1,184 @@
+/**
+ * Hosted-link layout styles. Per-institution branding is plumbed
+ * through as CSS custom properties (`--organization-primary`,
+ * `--organization-secondary`, `--organization-accent`) by App.tsx, so
+ * every section can opt in to branded accents without hard-coding
+ * colours.
+ */
+
+.plaidify-link {
+  max-width: var(--plaidify-max-width-content);
+  margin: 0 auto;
+  padding: var(--plaidify-space-6);
+  background: var(--plaidify-color-bg-surface);
+  color: var(--plaidify-color-fg-default);
+  border-radius: var(--plaidify-radius-lg);
+  box-shadow: var(--plaidify-shadow-md);
+  font-family: var(--plaidify-font-family-sans);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.link-step {
+  display: none;
+  flex-direction: column;
+  gap: var(--plaidify-space-4);
+}
+.link-step.active {
+  display: flex;
+}
+
+#institution-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--plaidify-space-2);
+  max-height: 50vh;
+  overflow-y: auto;
+}
+
+.institution-item {
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  align-items: center;
+  gap: var(--plaidify-space-3);
+  padding: var(--plaidify-space-3) var(--plaidify-space-4);
+  border: 1px solid var(--plaidify-color-border-default);
+  border-radius: var(--plaidify-radius-md);
+  background: var(--plaidify-color-bg-surface);
+  cursor: pointer;
+  transition:
+    background-color var(--plaidify-duration-fast) var(--plaidify-easing-standard),
+    border-color var(--plaidify-duration-fast) var(--plaidify-easing-standard),
+    transform var(--plaidify-duration-fast) var(--plaidify-easing-standard);
+}
+
+.institution-item:hover,
+.institution-item:focus-visible {
+  outline: none;
+  border-color: var(--organization-primary, var(--plaidify-color-border-focus));
+  background: var(--organization-secondary, var(--plaidify-color-bg-surface-alt));
+  box-shadow: var(--plaidify-shadow-focus);
+}
+
+.institution-item__logo {
+  border-radius: var(--plaidify-radius-sm);
+  display: block;
+  width: 32px;
+  height: 32px;
+}
+
+.institution-item__monogram {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--plaidify-radius-sm);
+  font-size: var(--plaidify-font-size-sm);
+  font-weight: var(--plaidify-font-weight-semibold);
+  background: var(--organization-primary, var(--plaidify-color-accent-default));
+  color: var(--organization-secondary, var(--plaidify-color-fg-on-accent));
+}
+
+.institution-item__name {
+  font-size: var(--plaidify-font-size-md);
+  font-weight: var(--plaidify-font-weight-medium);
+}
+
+.institution-item__category {
+  font-size: var(--plaidify-font-size-xs);
+  color: var(--plaidify-color-fg-muted);
+}
+
+.credentials-header {
+  display: flex;
+  align-items: center;
+  gap: var(--plaidify-space-3);
+}
+
+.credentials-header__logo {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--plaidify-radius-md);
+  display: block;
+}
+
+.credentials-hint {
+  margin: 0;
+  padding: var(--plaidify-space-3) var(--plaidify-space-4);
+  background: var(--organization-secondary, var(--plaidify-color-bg-surface-alt));
+  border-left: 3px solid var(--organization-primary, var(--plaidify-color-accent-default));
+  border-radius: var(--plaidify-radius-sm);
+  color: var(--plaidify-color-fg-muted);
+  font-size: var(--plaidify-font-size-sm);
+  line-height: var(--plaidify-line-height-normal);
+}
+
+#connect-btn,
+#mfa-submit-btn {
+  background: var(--organization-primary, var(--plaidify-color-accent-default));
+  color: var(--plaidify-color-fg-on-accent);
+  border: none;
+  border-radius: var(--plaidify-radius-md);
+  padding: var(--plaidify-space-3) var(--plaidify-space-5);
+  font-size: var(--plaidify-font-size-md);
+  font-weight: var(--plaidify-font-weight-semibold);
+  cursor: pointer;
+}
+#connect-btn:hover,
+#mfa-submit-btn:hover {
+  background: var(--organization-accent, var(--plaidify-color-accent-hover));
+}
+
+#institution-search,
+#link-username,
+#link-password,
+#mfa-code {
+  width: 100%;
+  padding: var(--plaidify-space-3) var(--plaidify-space-4);
+  border: 1px solid var(--plaidify-color-border-strong);
+  border-radius: var(--plaidify-radius-md);
+  background: var(--plaidify-color-bg-surface);
+  color: var(--plaidify-color-fg-default);
+  font-family: var(--plaidify-font-family-sans);
+  font-size: var(--plaidify-font-size-md);
+}
+#institution-search:focus,
+#link-username:focus,
+#link-password:focus,
+#mfa-code:focus {
+  outline: none;
+  border-color: var(--organization-primary, var(--plaidify-color-border-focus));
+  box-shadow: var(--plaidify-shadow-focus);
+}
+
+.reference-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--plaidify-space-3) var(--plaidify-space-4);
+  background: var(--plaidify-color-bg-surface-alt);
+  border-radius: var(--plaidify-radius-md);
+  font-family: var(--plaidify-font-family-mono);
+  font-size: var(--plaidify-font-size-sm);
+}
+.reference-label {
+  color: var(--plaidify-color-fg-muted);
+}
+.reference-value {
+  color: var(--plaidify-color-fg-default);
+  user-select: all;
+}

--- a/frontend-next/src/main.tsx
+++ b/frontend-next/src/main.tsx
@@ -4,6 +4,7 @@ import { createRoot } from "react-dom/client";
 import { App } from "./App";
 import "./design/tokens.css";
 import "./design/primitives.css";
+import "./link.css";
 
 const container = document.getElementById("root");
 if (!container) {

--- a/frontend-next/src/state.ts
+++ b/frontend-next/src/state.ts
@@ -28,6 +28,12 @@ export interface Institution {
   readonly name: string;
   readonly category?: string;
   readonly country?: string;
+  readonly logo_url?: string;
+  readonly primary_color?: string;
+  readonly secondary_color?: string;
+  readonly accent_color?: string;
+  readonly hint_copy?: string;
+  readonly auth_style?: "username_password" | "email_password" | "member_number";
 }
 
 export interface SuccessPayload {

--- a/src/organization_catalog.py
+++ b/src/organization_catalog.py
@@ -89,6 +89,13 @@ _CATEGORY_SPECS = (
     {
         "key": "finance",
         "label": "Finance",
+        "branding": {
+            "primary_color": "#0f4c81",
+            "secondary_color": "#e6efff",
+            "accent_color": "#f4a261",
+            "hint_copy": "Use the same username and password you use for online banking.",
+            "auth_style": "username_password",
+        },
         "brands": (
             "North Harbor Bank",
             "Summit Credit Union",
@@ -118,6 +125,13 @@ _CATEGORY_SPECS = (
     {
         "key": "utility",
         "label": "Utilities",
+        "branding": {
+            "primary_color": "#1f6f43",
+            "secondary_color": "#e7f4ec",
+            "accent_color": "#f2c14e",
+            "hint_copy": "Sign in with the email or account number on your utility bill.",
+            "auth_style": "email_password",
+        },
         "brands": (
             "Everstream Electric",
             "Northline Utilities",
@@ -141,6 +155,13 @@ _CATEGORY_SPECS = (
     {
         "key": "insurance",
         "label": "Insurance",
+        "branding": {
+            "primary_color": "#6a1b9a",
+            "secondary_color": "#f3e8ff",
+            "accent_color": "#ffb703",
+            "hint_copy": "Enter your policy portal credentials — usually the email on file.",
+            "auth_style": "email_password",
+        },
         "brands": (
             "Harbor Shield Insurance",
             "Summit Mutual",
@@ -162,6 +183,13 @@ _CATEGORY_SPECS = (
     {
         "key": "telecom",
         "label": "Telecom",
+        "branding": {
+            "primary_color": "#c2410c",
+            "secondary_color": "#ffedd5",
+            "accent_color": "#0ea5e9",
+            "hint_copy": "Use your wireless or subscriber account login.",
+            "auth_style": "username_password",
+        },
         "brands": (
             "Northern Signal",
             "Prairie Connect",
@@ -181,6 +209,13 @@ _CATEGORY_SPECS = (
     {
         "key": "healthcare",
         "label": "Healthcare",
+        "branding": {
+            "primary_color": "#0d9488",
+            "secondary_color": "#e0f7f4",
+            "accent_color": "#f43f5e",
+            "hint_copy": "Sign in with your patient portal or member-services credentials.",
+            "auth_style": "email_password",
+        },
         "brands": (
             "Civic Health Network",
             "Maple Care Alliance",
@@ -199,6 +234,13 @@ _CATEGORY_SPECS = (
     {
         "key": "government",
         "label": "Government",
+        "branding": {
+            "primary_color": "#1e293b",
+            "secondary_color": "#e2e8f0",
+            "accent_color": "#2563eb",
+            "hint_copy": "Use your citizen or resident services sign-in.",
+            "auth_style": "member_number",
+        },
         "brands": (
             "Civic Services Office",
             "Regional Benefits Administration",
@@ -218,6 +260,38 @@ _CATEGORY_SPECS = (
 
 def _slugify(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+
+
+def _monogram(name: str) -> str:
+    """Two-letter monogram from the most significant words in `name`."""
+    words = [w for w in re.split(r"\s+", re.sub(r"[^A-Za-z\s]+", " ", name)) if w]
+    if not words:
+        return "?"
+    stopwords = {"the", "of", "and", "for", "co", "inc", "ltd"}
+    meaningful = [w for w in words if w.lower() not in stopwords] or words
+    letters = "".join(w[0] for w in meaningful[:2]).upper()
+    return letters or "?"
+
+
+def _logo_svg(monogram: str, primary: str, secondary: str) -> str:
+    """Inline SVG logo placeholder — rendered via data: URL in the picker."""
+    return (
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64' role='img'>"
+        f"<rect width='64' height='64' rx='14' fill='{primary}'/>"
+        f"<text x='50%' y='54%' text-anchor='middle' dominant-baseline='middle' "
+        f"font-family='Inter, Segoe UI, system-ui, sans-serif' font-size='24' "
+        f"font-weight='600' fill='{secondary}'>{monogram}</text>"
+        "</svg>"
+    )
+
+
+def _logo_data_url(monogram: str, primary: str, secondary: str) -> str:
+    import base64
+
+    encoded = base64.b64encode(
+        _logo_svg(monogram, primary, secondary).encode("utf-8")
+    ).decode("ascii")
+    return f"data:image/svg+xml;base64,{encoded}"
 
 
 @lru_cache(maxsize=1)
@@ -289,6 +363,15 @@ def get_organization_catalog() -> tuple[dict[str, Any], ...]:
         for spec in _CATEGORY_SPECS:
             template_site = _resolve_template_site(spec["key"], country_code, templates)
             template = templates.get(template_site, {})
+            branding = spec.get("branding", {})
+            primary_color = branding.get("primary_color", "#1f2937")
+            secondary_color = branding.get("secondary_color", "#ffffff")
+            accent_color = branding.get("accent_color", "#2563eb")
+            hint_copy = branding.get(
+                "hint_copy",
+                "Use your online account credentials to continue.",
+            )
+            auth_style = branding.get("auth_style", "username_password")
 
             for region_code, region_name in regions:
                 for brand in spec["brands"]:
@@ -316,6 +399,8 @@ def get_organization_catalog() -> tuple[dict[str, Any], ...]:
                                 *spec["search_terms"],
                             )
                         ).lower()
+                        monogram = _monogram(brand)
+                        logo_url = _logo_data_url(monogram, primary_color, secondary_color)
                         catalog.append(
                             {
                                 "organization_id": organization_id,
@@ -334,6 +419,13 @@ def get_organization_catalog() -> tuple[dict[str, Any], ...]:
                                 "has_mfa": bool(template.get("has_mfa")),
                                 "supported": True,
                                 "read_only": True,
+                                "logo_url": logo_url,
+                                "logo_monogram": monogram,
+                                "primary_color": primary_color,
+                                "secondary_color": secondary_color,
+                                "accent_color": accent_color,
+                                "hint_copy": hint_copy,
+                                "auth_style": auth_style,
                                 "search_text": search_text,
                             }
                         )

--- a/tests/test_organization_catalog.py
+++ b/tests/test_organization_catalog.py
@@ -49,3 +49,26 @@ class TestOrganizationCatalog:
     def test_search_validates_pagination(self, client):
         response = client.get("/organizations/search", params={"limit": 0})
         assert response.status_code == 422
+
+    def test_results_expose_branding_metadata(self, client):
+        response = client.get("/organizations/search", params={"category": "finance", "limit": 1})
+        assert response.status_code == 200
+        result = response.json()["results"][0]
+        # #53: every entry ships logo + brand palette + auth affordances.
+        assert result["logo_url"].startswith("data:image/svg+xml;base64,")
+        assert result["logo_monogram"] and result["logo_monogram"].isupper()
+        assert result["primary_color"].startswith("#") and len(result["primary_color"]) == 7
+        assert result["secondary_color"].startswith("#") and len(result["secondary_color"]) == 7
+        assert result["accent_color"].startswith("#")
+        assert result["hint_copy"]
+        assert result["auth_style"] in {"username_password", "email_password", "member_number"}
+
+    def test_branding_differs_across_categories(self, client):
+        finance = client.get(
+            "/organizations/search", params={"category": "finance", "limit": 1}
+        ).json()["results"][0]
+        utility = client.get(
+            "/organizations/search", params={"category": "utility", "limit": 1}
+        ).json()["results"][0]
+        assert finance["primary_color"] != utility["primary_color"]
+        assert finance["auth_style"] != utility["auth_style"] or finance["hint_copy"] != utility["hint_copy"]


### PR DESCRIPTION
Closes #53.

## Backend
- Every category in `_CATEGORY_SPECS` now carries a `branding` dict: `primary_color`, `secondary_color`, `accent_color`, `hint_copy`, `auth_style`.
- New helpers `_monogram`, `_logo_svg`, `_logo_data_url` compute a stable 2-letter monogram and an inline SVG `data:image/svg+xml;base64,...` logo from the org name + palette.
- `get_organization_catalog()` now includes `logo_url`, `logo_monogram`, `primary_color`, `secondary_color`, `accent_color`, `hint_copy`, `auth_style` on every entry. These flow through `/organizations/search` and `/organizations/{id}` with no router changes.

## Frontend
- `api.ts`: `Organization` gains the 7 optional branding fields + an `OrganizationAuthStyle` union.
- `state.ts`: `Institution` carries branding so the credentials step can use it.
- `App.tsx`:
  - Institution picker items render a logo (`<img>` data URL) or monogram badge, use `primary_color`/`secondary_color` as CSS custom properties for hover/focus accents.
  - Credentials step exposes a branded header, a new `#provider-hint` paragraph (in addition to the existing consent list), and switches the identifier label + input `type`/`autocomplete`/`inputMode` based on `auth_style` (Email / Username / Member number).
- New `link.css` provides minimal layout + uses `--organization-*` custom properties so branding cascades without hard-coded colors.

## Tests
- Backend: 2 new catalog tests (branding fields present and differ across categories). All 7 tests pass.
- Frontend: extended SSR test to assert `data-organization-id`, the logo `src`, `#provider-hint`, hint copy, and the "Email" label when `auth_style=email_password`. 44/44 vitest tests pass.
- E2E: `tests/test_hosted_link_e2e.py` — all 3 pass; DOM contract preserved.
- typecheck + `npm run build` clean.