### PR TITLE
feat(#54): dynamic credential + MFA forms driven by connector schemas

### DIFF
--- a/connectors/hydro_one.json
+++ b/connectors/hydro_one.json
@@ -113,5 +113,54 @@
   "health_check": {
     "url": "https://www.hydroone.com",
     "expected_status": 200
+  },
+
+  "credential_schema": {
+    "submit_label": "Connect securely",
+    "fields": [
+      {
+        "id": "username",
+        "label": "Hydro One username or email",
+        "type": "text",
+        "autocomplete": "username",
+        "placeholder": "you@example.com",
+        "help_text": "The username or email you use to sign in to myAccount.",
+        "required": true,
+        "min_length": 3,
+        "max_length": 128
+      },
+      {
+        "id": "password",
+        "label": "Password",
+        "type": "password",
+        "autocomplete": "current-password",
+        "required": true,
+        "secret": true,
+        "reveal": true,
+        "min_length": 6,
+        "max_length": 128
+      }
+    ]
+  },
+
+  "mfa_schema": {
+    "otp_input": {
+      "title": "Enter your 6-digit verification code",
+      "help_text": "Hydro One just sent a code to your phone or email.",
+      "submit_label": "Verify and continue",
+      "fields": [
+        {
+          "id": "code",
+          "label": "Verification code",
+          "type": "text",
+          "inputmode": "numeric",
+          "autocomplete": "one-time-code",
+          "pattern": "^\\d{4,8}$",
+          "min_length": 4,
+          "max_length": 8,
+          "required": true
+        }
+      ]
+    }
   }
 }

--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -12,11 +12,16 @@ import {
   LinkApi,
   pollLinkSession as defaultPollLinkSession,
   type ConnectResponse,
+  type CredentialSchema,
   type LinkSessionStatus,
+  type MfaSchema,
+  type MfaSchemaEntry,
   type Organization,
   type PollOptions,
+  type SchemaField,
 } from "./api";
 import { detectNativeBridges, readHostedLinkConfig } from "./config";
+import { DynamicForm, validateSchemaValues } from "./DynamicForm";
 import { EventDelivery, postBridgeEvent } from "./events";
 import {
   flowReducer,
@@ -62,9 +67,11 @@ export interface AppProps {
 export function App(props: AppProps = {}) {
   const [state, dispatch] = useReducer(flowReducer, props.initialState ?? initialFlowState);
   const [query, setQuery] = useState("");
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [mfaCode, setMfaCode] = useState("");
+  const [credentialValues, setCredentialValues] = useState<Readonly<Record<string, string>>>({});
+  const [credentialErrors, setCredentialErrors] = useState<Readonly<Record<string, string>>>({});
+  const [mfaValues, setMfaValues] = useState<Readonly<Record<string, string>>>({});
+  const [mfaErrors, setMfaErrors] = useState<Readonly<Record<string, string>>>({});
+  const [mfaType, setMfaType] = useState<string>("otp_input");
   const [organizations, setOrganizations] = useState<readonly Organization[]>(
     props.seedInstitutions ?? [],
   );
@@ -90,6 +97,16 @@ export function App(props: AppProps = {}) {
 
   const encryptFn = props.encryptCredentials ?? defaultEncryptCredentials;
   const pollFn = props.pollLinkSession ?? defaultPollLinkSession;
+
+  const credentialSchema: CredentialSchema = useMemo(
+    () =>
+      state.institution?.credential_schema ?? fallbackCredentialSchema(state.institution?.auth_style),
+    [state.institution],
+  );
+  const mfaSchemaEntry: MfaSchemaEntry = useMemo(
+    () => resolveMfaSchemaEntry(state.institution?.mfa_schema, mfaType),
+    [state.institution, mfaType],
+  );
 
   // Build the API client + event delivery once per linkToken.
   if (apiRef.current === null && configRef.current.linkToken) {
@@ -268,6 +285,9 @@ export function App(props: AppProps = {}) {
         const message =
           (response.metadata as { message?: string } | null)?.message ??
           "Enter the verification code from your provider to continue.";
+        setMfaType(response.mfa_type ?? "otp_input");
+        setMfaValues({});
+        setMfaErrors({});
         dispatch({ type: "MFA_REQUIRED", prompt: message });
         emit("MFA_REQUIRED", {
           mfa_type: response.mfa_type ?? "otp",
@@ -282,6 +302,9 @@ export function App(props: AppProps = {}) {
           return;
         }
         if (terminal.status === "mfa_required") {
+          setMfaType(terminal.mfa_type ?? "otp_input");
+          setMfaValues({});
+          setMfaErrors({});
           dispatch({
             type: "MFA_REQUIRED",
             prompt:
@@ -343,13 +366,36 @@ export function App(props: AppProps = {}) {
   );
 
   const onSubmitCredentials = useCallback(() => {
-    void runConnect(username, password);
-  }, [password, runConnect, username]);
+    const errors = validateSchemaValues(credentialSchema.fields, credentialValues);
+    if (errors.length) {
+      const map: Record<string, string> = {};
+      for (const err of errors) map[err.field] = err.message;
+      setCredentialErrors(map);
+      return;
+    }
+    setCredentialErrors({});
+    const usernameValue = credentialValues.username ?? "";
+    const passwordValue = credentialValues.password ?? "";
+    void runConnect(usernameValue.trim(), passwordValue);
+  }, [credentialSchema, credentialValues, runConnect]);
 
   const onSubmitMfa = useCallback(async () => {
     const api = apiRef.current;
     const sessionId = sessionIdRef.current;
-    if (!api || !sessionId || !mfaCode.trim()) {
+    if (!api || !sessionId) {
+      return;
+    }
+    const errors = validateSchemaValues(mfaSchemaEntry.fields, mfaValues);
+    if (errors.length) {
+      const map: Record<string, string> = {};
+      for (const err of errors) map[err.field] = err.message;
+      setMfaErrors(map);
+      return;
+    }
+    setMfaErrors({});
+    const codeValue = (mfaValues.code ?? "").trim();
+    // Push-type prompts omit fields — treat the submit click as confirmation.
+    if (!codeValue && mfaSchemaEntry.fields.length > 0) {
       return;
     }
     dispatch({ type: "SUBMIT_MFA" });
@@ -357,7 +403,7 @@ export function App(props: AppProps = {}) {
     try {
       const response = await api.submitMfa({
         sessionId,
-        code: mfaCode.trim(),
+        code: codeValue,
       });
       await handleConnectResponse(api, response);
     } catch (err) {
@@ -365,7 +411,7 @@ export function App(props: AppProps = {}) {
       dispatch({ type: "FAIL", payload: { message } });
       emit("ERROR", { error: message, site: siteRef.current });
     }
-  }, [emit, handleConnectResponse, mfaCode]);
+  }, [emit, handleConnectResponse, mfaSchemaEntry, mfaValues]);
 
   const consent = useMemo(() => CONSENT_BULLETS, []);
 
@@ -494,35 +540,31 @@ export function App(props: AppProps = {}) {
             <li key={item}>{item}</li>
           ))}
         </ul>
-        <label htmlFor="link-username">
-          {state.institution?.auth_style === "email_password"
-            ? "Email"
-            : state.institution?.auth_style === "member_number"
-              ? "Member number"
-              : "Username"}
-        </label>
-        <input
-          id="link-username"
-          type={state.institution?.auth_style === "email_password" ? "email" : "text"}
-          autoComplete={
-            state.institution?.auth_style === "email_password" ? "email" : "username"
-          }
-          inputMode={
-            state.institution?.auth_style === "member_number" ? "numeric" : undefined
-          }
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
-        <label htmlFor="link-password">Password</label>
-        <input
-          id="link-password"
-          type="password"
-          autoComplete="current-password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
+        <DynamicForm
+          fields={credentialSchema.fields}
+          values={credentialValues}
+          errors={credentialErrors}
+          onChange={(id, value) => {
+            setCredentialValues((prev) => ({ ...prev, [id]: value }));
+            if (credentialErrors[id]) {
+              setCredentialErrors((prev) => {
+                const next = { ...prev };
+                delete next[id];
+                return next;
+              });
+            }
+          }}
+          onBlur={(id) => {
+            const field = credentialSchema.fields.find((f) => f.id === id);
+            if (!field) return;
+            const errors = validateSchemaValues([field], credentialValues);
+            if (errors.length) {
+              setCredentialErrors((prev) => ({ ...prev, [id]: errors[0].message }));
+            }
+          }}
         />
         <button id="connect-btn" type="button" onClick={onSubmitCredentials}>
-          Continue
+          {credentialSchema.submit_label ?? "Continue"}
         </button>
       </section>
 
@@ -540,19 +582,53 @@ export function App(props: AppProps = {}) {
         className={state.step === "mfa" ? "link-step active" : "link-step"}
         role="region"
         aria-label="Finish verification"
+        style={
+          state.institution?.primary_color
+            ? ({
+                "--organization-primary": state.institution.primary_color,
+                "--organization-secondary":
+                  state.institution.secondary_color ?? "transparent",
+                "--organization-accent":
+                  state.institution.accent_color ?? state.institution.primary_color,
+              } as React.CSSProperties)
+            : undefined
+        }
       >
+        {mfaSchemaEntry.title ? (
+          <h2 id="mfa-title">{mfaSchemaEntry.title}</h2>
+        ) : null}
         <p id="mfa-message">{state.mfaPrompt ?? ""}</p>
-        <label htmlFor="mfa-code">Verification code</label>
-        <input
-          id="mfa-code"
-          type="text"
-          inputMode="numeric"
-          autoComplete="one-time-code"
-          value={mfaCode}
-          onChange={(e) => setMfaCode(e.target.value)}
+        {mfaSchemaEntry.help_text ? (
+          <p id="mfa-help" className="credentials-hint">
+            {mfaSchemaEntry.help_text}
+          </p>
+        ) : null}
+        <DynamicForm
+          idPrefix="mfa"
+          fields={mfaSchemaEntry.fields}
+          values={mfaValues}
+          errors={mfaErrors}
+          onChange={(id, value) => {
+            setMfaValues((prev) => ({ ...prev, [id]: value }));
+            if (mfaErrors[id]) {
+              setMfaErrors((prev) => {
+                const next = { ...prev };
+                delete next[id];
+                return next;
+              });
+            }
+          }}
+          onBlur={(id) => {
+            const field = mfaSchemaEntry.fields.find((f) => f.id === id);
+            if (!field) return;
+            const errors = validateSchemaValues([field], mfaValues);
+            if (errors.length) {
+              setMfaErrors((prev) => ({ ...prev, [id]: errors[0].message }));
+            }
+          }}
         />
         <button id="mfa-submit-btn" type="button" onClick={() => void onSubmitMfa()}>
-          Verify and continue
+          {mfaSchemaEntry.submit_label ?? "Verify and continue"}
         </button>
       </section>
 
@@ -590,4 +666,109 @@ export function App(props: AppProps = {}) {
       </section>
     </main>
   );
+}
+
+// ── Schema fallbacks ─────────────────────────────────────────────────────────
+// Mirror `organization_catalog._default_credential_schema` and
+// `_default_mfa_schema` so the UI still renders something sensible if the
+// backend omits them (e.g. older catalog payload or unit tests).
+
+const DEFAULT_CRED_FIELDS: Record<string, readonly SchemaField[]> = {
+  username_password: [
+    {
+      id: "username",
+      label: "Username",
+      type: "text",
+      autocomplete: "username",
+      required: true,
+      min_length: 3,
+      max_length: 128,
+    },
+    {
+      id: "password",
+      label: "Password",
+      type: "password",
+      autocomplete: "current-password",
+      required: true,
+      secret: true,
+      reveal: true,
+      min_length: 6,
+      max_length: 128,
+    },
+  ],
+  email_password: [
+    {
+      id: "username",
+      label: "Email",
+      type: "email",
+      autocomplete: "email",
+      required: true,
+      min_length: 5,
+      max_length: 254,
+    },
+    {
+      id: "password",
+      label: "Password",
+      type: "password",
+      autocomplete: "current-password",
+      required: true,
+      secret: true,
+      reveal: true,
+      min_length: 6,
+      max_length: 128,
+    },
+  ],
+  member_number: [
+    {
+      id: "username",
+      label: "Member number",
+      type: "text",
+      autocomplete: "username",
+      inputmode: "numeric",
+      required: true,
+      min_length: 4,
+      max_length: 32,
+    },
+    {
+      id: "password",
+      label: "Password",
+      type: "password",
+      autocomplete: "current-password",
+      required: true,
+      secret: true,
+      reveal: true,
+      min_length: 6,
+      max_length: 128,
+    },
+  ],
+};
+
+function fallbackCredentialSchema(authStyle?: string): CredentialSchema {
+  const fields =
+    DEFAULT_CRED_FIELDS[authStyle ?? "username_password"] ??
+    DEFAULT_CRED_FIELDS.username_password;
+  return { submit_label: "Connect securely", fields };
+}
+
+const DEFAULT_MFA_ENTRY: MfaSchemaEntry = {
+  title: "Enter your verification code",
+  help_text: "Check your phone, email, or authenticator app for the code.",
+  submit_label: "Verify and continue",
+  fields: [
+    {
+      id: "code",
+      label: "Verification code",
+      type: "text",
+      inputmode: "numeric",
+      autocomplete: "one-time-code",
+      pattern: "^\\d{4,8}$",
+      min_length: 4,
+      max_length: 8,
+      required: true,
+    },
+  ],
+};
+
+function resolveMfaSchemaEntry(schema: MfaSchema | undefined, type: string): MfaSchemaEntry {
+  return (schema?.[type] ?? schema?.otp_input ?? DEFAULT_MFA_ENTRY) as MfaSchemaEntry;
 }

--- a/frontend-next/src/DynamicForm.test.tsx
+++ b/frontend-next/src/DynamicForm.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { DynamicForm, validateSchemaValues } from "./DynamicForm";
+import type { SchemaField } from "./api";
+
+const fields: readonly SchemaField[] = [
+  {
+    id: "username",
+    label: "Email",
+    type: "email",
+    required: true,
+    pattern: "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$",
+  },
+  {
+    id: "password",
+    label: "Password",
+    type: "password",
+    required: true,
+    secret: true,
+    reveal: true,
+    min_length: 6,
+  },
+];
+
+describe("validateSchemaValues", () => {
+  it("reports required fields as missing", () => {
+    const errors = validateSchemaValues(fields, {});
+    expect(errors.map((e) => e.field)).toEqual(["username", "password"]);
+  });
+
+  it("enforces regex patterns", () => {
+    const errors = validateSchemaValues(fields, { username: "not-an-email", password: "hunter22" });
+    expect(errors).toEqual([
+      { field: "username", message: "Email is not in the expected format." },
+    ]);
+  });
+
+  it("enforces min_length", () => {
+    const errors = validateSchemaValues(fields, { username: "a@b.co", password: "hi" });
+    expect(errors).toEqual([
+      { field: "password", message: "Password must be at least 6 characters." },
+    ]);
+  });
+
+  it("accepts valid values", () => {
+    const errors = validateSchemaValues(fields, {
+      username: "a@b.co",
+      password: "hunter22",
+    });
+    expect(errors).toEqual([]);
+  });
+});
+
+describe("DynamicForm", () => {
+  it("renders prefixed ids with the right input types", () => {
+    const html = renderToString(
+      <DynamicForm fields={fields} values={{}} onChange={() => {}} />,
+    );
+    expect(html).toContain('id="link-username"');
+    expect(html).toContain('id="link-password"');
+    expect(html).toContain('type="email"');
+    expect(html).toContain('type="password"');
+  });
+
+  it("fires onChange when the user types", () => {
+    const onChange = vi.fn();
+    render(<DynamicForm fields={fields} values={{}} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText("Email"), { target: { value: "a@b.co" } });
+    expect(onChange).toHaveBeenCalledWith("username", "a@b.co");
+  });
+
+  it("toggles password reveal via the Show/Hide button", () => {
+    render(<DynamicForm fields={fields} values={{ password: "secret" }} onChange={() => {}} />);
+    const input = screen.getByLabelText("Password") as HTMLInputElement;
+    expect(input.type).toBe("password");
+    fireEvent.click(screen.getByRole("button", { name: /show password/i }));
+    expect((screen.getByLabelText("Password") as HTMLInputElement).type).toBe("text");
+  });
+
+  it("renders inline errors with role=alert", () => {
+    render(
+      <DynamicForm
+        fields={fields}
+        values={{ username: "" }}
+        errors={{ username: "Email is required." }}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Email is required.");
+  });
+});

--- a/frontend-next/src/DynamicForm.tsx
+++ b/frontend-next/src/DynamicForm.tsx
@@ -1,0 +1,162 @@
+/**
+ * DynamicForm — renders a connector-provided field schema as HTML inputs
+ * with inline validation. The hosted-link flow uses this for both the
+ * credentials step and the MFA step. Design goals:
+ *
+ *  1. Backwards-compatible DOM IDs: each field gets `id="link-<field.id>"`
+ *     and `name="<field.id>"`. The existing Playwright E2E relies on
+ *     `#link-username`, `#link-password`, `#mfa-code`.
+ *  2. Inline validation: `required`, `pattern`, `min_length`, `max_length`
+ *     are enforced in JS so error states show up below the field before
+ *     the request is sent. HTML constraint attributes also double as a
+ *     fallback when JS is disabled.
+ *  3. Password reveal: fields with `secret: true` and `reveal: true`
+ *     render a toggle that flips the input between `type="password"` and
+ *     `type="text"`.
+ */
+import { useId, useMemo, useState } from "react";
+
+import type { SchemaField } from "./api";
+
+export interface FieldValidationError {
+  readonly field: string;
+  readonly message: string;
+}
+
+export function validateSchemaValues(
+  fields: readonly SchemaField[],
+  values: Readonly<Record<string, string>>,
+): FieldValidationError[] {
+  const errors: FieldValidationError[] = [];
+  for (const field of fields) {
+    const raw = values[field.id] ?? "";
+    const value = raw.trim();
+    if (field.required && !value) {
+      errors.push({ field: field.id, message: `${field.label} is required.` });
+      continue;
+    }
+    if (!value) continue;
+    if (field.min_length !== undefined && value.length < field.min_length) {
+      errors.push({
+        field: field.id,
+        message: `${field.label} must be at least ${field.min_length} characters.`,
+      });
+      continue;
+    }
+    if (field.max_length !== undefined && value.length > field.max_length) {
+      errors.push({
+        field: field.id,
+        message: `${field.label} must be at most ${field.max_length} characters.`,
+      });
+      continue;
+    }
+    if (field.pattern) {
+      try {
+        const re = new RegExp(field.pattern);
+        if (!re.test(value)) {
+          errors.push({
+            field: field.id,
+            message: `${field.label} is not in the expected format.`,
+          });
+        }
+      } catch {
+        // Bad pattern from the connector — ignore rather than block the user.
+      }
+    }
+  }
+  return errors;
+}
+
+export interface DynamicFormProps {
+  readonly idPrefix?: string;
+  readonly fields: readonly SchemaField[];
+  readonly values: Readonly<Record<string, string>>;
+  readonly errors?: Readonly<Record<string, string>>;
+  readonly onChange: (id: string, value: string) => void;
+  readonly onBlur?: (id: string) => void;
+  readonly disabled?: boolean;
+}
+
+export function DynamicForm({
+  idPrefix = "link",
+  fields,
+  values,
+  errors,
+  onChange,
+  onBlur,
+  disabled,
+}: DynamicFormProps) {
+  const [revealed, setRevealed] = useState<Readonly<Record<string, boolean>>>({});
+  const describeBaseId = useId();
+
+  const resolvedFields = useMemo(() => fields, [fields]);
+
+  return (
+    <div className="dynamic-form">
+      {resolvedFields.map((field) => {
+        const domId = `${idPrefix}-${field.id}`;
+        const helpId = `${describeBaseId}-${field.id}-help`;
+        const errorId = `${describeBaseId}-${field.id}-error`;
+        const fieldError = errors?.[field.id];
+        const isSecret = field.type === "password" || field.secret;
+        const revealToggle = isSecret && field.reveal !== false;
+        const revealed_ = revealed[field.id] === true;
+        const resolvedType = isSecret && revealed_ ? "text" : field.type;
+
+        return (
+          <div className="dynamic-form__field" key={field.id}>
+            <label htmlFor={domId}>{field.label}</label>
+            <div className="dynamic-form__control">
+              <input
+                id={domId}
+                name={field.id}
+                type={resolvedType}
+                autoComplete={field.autocomplete}
+                inputMode={field.inputmode}
+                placeholder={field.placeholder}
+                required={field.required}
+                minLength={field.min_length}
+                maxLength={field.max_length}
+                pattern={field.pattern}
+                value={values[field.id] ?? ""}
+                aria-invalid={fieldError ? true : undefined}
+                aria-describedby={
+                  [fieldError ? errorId : null, field.help_text ? helpId : null]
+                    .filter(Boolean)
+                    .join(" ") || undefined
+                }
+                disabled={disabled}
+                onChange={(e) => onChange(field.id, e.target.value)}
+                onBlur={() => onBlur?.(field.id)}
+              />
+              {revealToggle ? (
+                <button
+                  type="button"
+                  className="dynamic-form__reveal"
+                  aria-pressed={revealed_}
+                  aria-label={revealed_ ? `Hide ${field.label}` : `Show ${field.label}`}
+                  onClick={() =>
+                    setRevealed((prev) => ({ ...prev, [field.id]: !prev[field.id] }))
+                  }
+                  disabled={disabled}
+                >
+                  {revealed_ ? "Hide" : "Show"}
+                </button>
+              ) : null}
+            </div>
+            {field.help_text ? (
+              <p id={helpId} className="dynamic-form__help">
+                {field.help_text}
+              </p>
+            ) : null}
+            {fieldError ? (
+              <p id={errorId} className="dynamic-form__error" role="alert">
+                {fieldError}
+              </p>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend-next/src/api.ts
+++ b/frontend-next/src/api.ts
@@ -24,6 +24,38 @@ export type OrganizationAuthStyle =
   | "email_password"
   | "member_number";
 
+export type SchemaFieldType = "text" | "email" | "password" | "tel" | "number";
+
+export interface SchemaField {
+  readonly id: string;
+  readonly label: string;
+  readonly type: SchemaFieldType;
+  readonly autocomplete?: string;
+  readonly inputmode?: "text" | "numeric" | "tel" | "email" | "decimal" | "search" | "url" | "none";
+  readonly placeholder?: string;
+  readonly help_text?: string;
+  readonly pattern?: string;
+  readonly min_length?: number;
+  readonly max_length?: number;
+  readonly required?: boolean;
+  readonly secret?: boolean;
+  readonly reveal?: boolean;
+}
+
+export interface CredentialSchema {
+  readonly fields: readonly SchemaField[];
+  readonly submit_label?: string;
+}
+
+export interface MfaSchemaEntry {
+  readonly title?: string;
+  readonly help_text?: string;
+  readonly submit_label?: string;
+  readonly fields: readonly SchemaField[];
+}
+
+export type MfaSchema = Readonly<Record<string, MfaSchemaEntry>>;
+
 export interface Organization {
   readonly organization_id: string;
   readonly name: string;
@@ -40,6 +72,8 @@ export interface Organization {
   readonly accent_color?: string;
   readonly hint_copy?: string;
   readonly auth_style?: OrganizationAuthStyle;
+  readonly credential_schema?: CredentialSchema;
+  readonly mfa_schema?: MfaSchema;
 }
 
 export interface OrganizationSearchResponse {

--- a/frontend-next/src/state.ts
+++ b/frontend-next/src/state.ts
@@ -23,6 +23,8 @@ export type FlowStep =
   | "success"
   | "error";
 
+import type { CredentialSchema, MfaSchema } from "./api";
+
 export interface Institution {
   readonly site: string;
   readonly name: string;
@@ -34,6 +36,8 @@ export interface Institution {
   readonly accent_color?: string;
   readonly hint_copy?: string;
   readonly auth_style?: "username_password" | "email_password" | "member_number";
+  readonly credential_schema?: CredentialSchema;
+  readonly mfa_schema?: MfaSchema;
 }
 
 export interface SuccessPayload {

--- a/src/core/blueprint.py
+++ b/src/core/blueprint.py
@@ -380,6 +380,28 @@ class BlueprintV2(BaseModel):
         None,
         description="Health check configuration.",
     )
+    credential_schema: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Optional UI-facing schema describing credential fields for the hosted "
+            "Link flow (#54). Keys: `fields` (list of field descriptors) and "
+            "`submit_label`. Each field has `id`, `label`, `type` (text|email|"
+            "password|tel|number), optional `autocomplete`, `inputmode`, "
+            "`placeholder`, `help_text`, `pattern`, `min_length`, `max_length`, "
+            "`required`, `secret`, `reveal`. When omitted, the frontend derives "
+            "a default from the organization's `auth_style`."
+        ),
+    )
+    mfa_schema: Optional[Dict[str, Any]] = Field(
+        None,
+        description=(
+            "Optional UI-facing schema describing MFA prompts keyed by MFA "
+            "type (sms, totp, security_question, push, email_code). Each entry "
+            "has a `title`, `help_text`, `fields` (same descriptor shape as "
+            "credential_schema), and optional `submit_label`. When omitted, "
+            "the frontend renders a single numeric `code` field."
+        ),
+    )
 
     @field_validator("schema_version")
     @classmethod

--- a/src/organization_catalog.py
+++ b/src/organization_catalog.py
@@ -294,6 +294,144 @@ def _logo_data_url(monogram: str, primary: str, secondary: str) -> str:
     return f"data:image/svg+xml;base64,{encoded}"
 
 
+_DEFAULT_CREDENTIAL_SCHEMAS: dict[str, dict[str, Any]] = {
+    "username_password": {
+        "submit_label": "Connect securely",
+        "fields": [
+            {
+                "id": "username",
+                "label": "Username",
+                "type": "text",
+                "autocomplete": "username",
+                "required": True,
+                "min_length": 3,
+                "max_length": 128,
+            },
+            {
+                "id": "password",
+                "label": "Password",
+                "type": "password",
+                "autocomplete": "current-password",
+                "required": True,
+                "secret": True,
+                "reveal": True,
+                "min_length": 6,
+                "max_length": 128,
+            },
+        ],
+    },
+    "email_password": {
+        "submit_label": "Connect securely",
+        "fields": [
+            {
+                "id": "username",
+                "label": "Email",
+                "type": "email",
+                "autocomplete": "email",
+                "required": True,
+                "pattern": r"^[^@\s]+@[^@\s]+\.[^@\s]+$",
+                "help_text": "Use the email address on file with your account.",
+                "min_length": 5,
+                "max_length": 254,
+            },
+            {
+                "id": "password",
+                "label": "Password",
+                "type": "password",
+                "autocomplete": "current-password",
+                "required": True,
+                "secret": True,
+                "reveal": True,
+                "min_length": 6,
+                "max_length": 128,
+            },
+        ],
+    },
+    "member_number": {
+        "submit_label": "Connect securely",
+        "fields": [
+            {
+                "id": "username",
+                "label": "Member number",
+                "type": "text",
+                "autocomplete": "username",
+                "inputmode": "numeric",
+                "pattern": r"^[0-9\-]{4,32}$",
+                "help_text": "Your member or account number as it appears on your statement.",
+                "required": True,
+                "min_length": 4,
+                "max_length": 32,
+            },
+            {
+                "id": "password",
+                "label": "Password",
+                "type": "password",
+                "autocomplete": "current-password",
+                "required": True,
+                "secret": True,
+                "reveal": True,
+                "min_length": 6,
+                "max_length": 128,
+            },
+        ],
+    },
+}
+
+
+_DEFAULT_MFA_SCHEMA: dict[str, dict[str, Any]] = {
+    "otp_input": {
+        "title": "Enter your verification code",
+        "help_text": "Check your phone, email, or authenticator app for the code.",
+        "submit_label": "Verify and continue",
+        "fields": [
+            {
+                "id": "code",
+                "label": "Verification code",
+                "type": "text",
+                "inputmode": "numeric",
+                "autocomplete": "one-time-code",
+                "pattern": r"^\d{4,8}$",
+                "min_length": 4,
+                "max_length": 8,
+                "required": True,
+            }
+        ],
+    },
+    "security_question": {
+        "title": "Answer your security question",
+        "submit_label": "Continue",
+        "fields": [
+            {
+                "id": "code",
+                "label": "Answer",
+                "type": "text",
+                "autocomplete": "off",
+                "required": True,
+                "min_length": 1,
+                "max_length": 128,
+            }
+        ],
+    },
+    "push": {
+        "title": "Approve the push notification on your device",
+        "help_text": "Waiting for you to approve the sign-in from your authenticator app.",
+        "submit_label": "I approved it",
+        "fields": [],
+    },
+}
+
+
+def _default_credential_schema(auth_style: str) -> dict[str, Any]:
+    return _DEFAULT_CREDENTIAL_SCHEMAS.get(
+        auth_style, _DEFAULT_CREDENTIAL_SCHEMAS["username_password"]
+    )
+
+
+def _default_mfa_schema() -> dict[str, Any]:
+    # Return a fresh dict to avoid downstream mutation.
+    return {key: dict(value) for key, value in _DEFAULT_MFA_SCHEMA.items()}
+
+
 @lru_cache(maxsize=1)
 def _load_connector_templates() -> dict[str, dict[str, Any]]:
     connectors_path = Path(settings.connectors_dir).resolve()
@@ -319,6 +457,9 @@ def _load_connector_templates() -> dict[str, dict[str, Any]]:
             "domain": blueprint.domain,
             "has_mfa": blueprint.mfa is not None,
             "tags": tags,
+            "credential_schema": blueprint.credential_schema,
+            "mfa_schema": blueprint.mfa_schema,
+            "mfa_type": blueprint.mfa.type.value if blueprint.mfa else None,
         }
 
     return templates
@@ -372,6 +513,12 @@ def get_organization_catalog() -> tuple[dict[str, Any], ...]:
                 "Use your online account credentials to continue.",
             )
             auth_style = branding.get("auth_style", "username_password")
+            # Synthetic directory entries render with schemas derived from the
+            # category's `auth_style`. Connector-specific `credential_schema` /
+            # `mfa_schema` blocks still live in the blueprint JSON for real
+            # integrations and are surfaced via /blueprints.
+            credential_schema = _default_credential_schema(auth_style)
+            mfa_schema = _default_mfa_schema()
 
             for region_code, region_name in regions:
                 for brand in spec["brands"]:
@@ -426,6 +573,8 @@ def get_organization_catalog() -> tuple[dict[str, Any], ...]:
                                 "accent_color": accent_color,
                                 "hint_copy": hint_copy,
                                 "auth_style": auth_style,
+                                "credential_schema": credential_schema,
+                                "mfa_schema": mfa_schema,
                                 "search_text": search_text,
                             }
                         )

--- a/tests/test_organization_catalog.py
+++ b/tests/test_organization_catalog.py
@@ -72,3 +72,38 @@ class TestOrganizationCatalog:
         ).json()["results"][0]
         assert finance["primary_color"] != utility["primary_color"]
         assert finance["auth_style"] != utility["auth_style"] or finance["hint_copy"] != utility["hint_copy"]
+
+    def test_credential_schema_defaults_follow_auth_style(self, client):
+        finance = client.get(
+            "/organizations/search", params={"category": "finance", "limit": 1}
+        ).json()["results"][0]
+        utility = client.get(
+            "/organizations/search", params={"category": "utility", "limit": 1}
+        ).json()["results"][0]
+        government = client.get(
+            "/organizations/search", params={"category": "government", "limit": 1}
+        ).json()["results"][0]
+
+        # Every org ships a credential_schema + mfa_schema (#54).
+        for org in (finance, utility, government):
+            schema = org["credential_schema"]
+            assert isinstance(schema.get("fields"), list) and schema["fields"]
+            field_ids = [field["id"] for field in schema["fields"]]
+            assert "username" in field_ids and "password" in field_ids
+            mfa_schema = org["mfa_schema"]
+            assert isinstance(mfa_schema, dict) and mfa_schema
+
+        finance_username = next(
+            field for field in finance["credential_schema"]["fields"] if field["id"] == "username"
+        )
+        utility_username = next(
+            field for field in utility["credential_schema"]["fields"] if field["id"] == "username"
+        )
+        government_username = next(
+            field
+            for field in government["credential_schema"]["fields"]
+            if field["id"] == "username"
+        )
+        assert finance_username["type"] == "text"
+        assert utility_username["type"] == "email"
+        assert government_username["label"].lower().startswith("member")


### PR DESCRIPTION
Closes #54.

## Backend
- `BlueprintV2` gains optional top-level `credential_schema` and `mfa_schema` dicts (loose `Dict[str, Any]` — validated UI-side).
- `organization_catalog.py` derives auth-style-aware defaults for every synthetic directory entry:
  - `username_password`: text username + password
  - `email_password`: email username w/ email-regex pattern + password
  - `member_number`: numeric input-mode username + password
  - MFA default covers `otp_input`, `security_question`, `push`.
- All catalog entries expose `credential_schema` and `mfa_schema` via `/organizations/search` and `/organizations/{id}`.
- Connector-specific schemas live in the blueprint JSON and surface via `/blueprints`; `connectors/hydro_one.json` now ships an explicit credential + MFA schema as a reference.

## Frontend
- New `DynamicForm.tsx` renders a field schema with inline validation (`required`, regex `pattern`, `min_length`, `max_length`), ARIA error wiring, and optional password reveal toggle.
- `App.tsx` threads the resolved `credential_schema` / `mfa_schema` through state and renders both steps dynamically. Backwards-compatible DOM IDs (`#link-username`, `#link-password`, `#mfa-code`, `#connect-btn`, `#mfa-submit-btn`) preserved for the Playwright E2E.
- `api.ts` and `state.ts` expose new `SchemaField`, `CredentialSchema`, `MfaSchemaEntry`, `MfaSchema` types.

## Tests
- `test_organization_catalog.py`: asserts `credential_schema` + `mfa_schema` ship and follow `auth_style` (email vs text vs member-number). Backend suite 46/46 pass.
- `DynamicForm.test.tsx`: covers validation (required, pattern, min_length, valid), DOM IDs, onChange, password reveal, and inline errors. Frontend suite 52/52 pass.
- `tests/test_hosted_link_e2e.py`: DOM contract preserved, all 3 passing.
- typecheck + `npm run build` clean.