### PR TITLE
feat(link): error taxonomy + remediation screen (#55)

### DIFF
--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -22,6 +22,12 @@ import {
 } from "./api";
 import { detectNativeBridges, readHostedLinkConfig } from "./config";
 import { DynamicForm, validateSchemaValues } from "./DynamicForm";
+import {
+  classifyError,
+  remediationFor,
+  type LinkErrorCode,
+  type RemediationAction,
+} from "./errorTaxonomy";
 import { EventDelivery, postBridgeEvent } from "./events";
 import {
   flowReducer,
@@ -202,10 +208,39 @@ export function App(props: AppProps = {}) {
   // Emit EXIT on unmount so the server can reconcile abandoned sessions.
   useEffect(() => {
     return () => {
-      emit("EXIT", { reason: "unmount" });
+      emit("EXIT", {
+        reason: "unmount",
+        error_code: state.error?.code ?? null,
+      });
       deliveryRef.current?.dispose();
     };
-  }, [emit]);
+  }, [emit, state.error?.code]);
+
+  const failWith = useCallback(
+    (err: unknown, options: { fallbackCode?: LinkErrorCode; site?: string | null } = {}) => {
+      const resolvedCode: LinkErrorCode = (() => {
+        const classified = classifyError(err);
+        if (classified === "internal_error" && options.fallbackCode) {
+          return options.fallbackCode;
+        }
+        return classified;
+      })();
+      const message =
+        (err && typeof err === "object" && (err as { message?: unknown }).message) ||
+        (typeof err === "string" ? err : "") ||
+        "Something went wrong.";
+      dispatch({
+        type: "FAIL",
+        payload: { message: String(message), code: resolvedCode },
+      });
+      emit("ERROR", {
+        error: String(message),
+        error_code: resolvedCode,
+        site: options.site ?? siteRef.current,
+      });
+    },
+    [emit],
+  );
 
   const onSelectInstitution = useCallback(
     (organization: Organization) => {
@@ -236,17 +271,15 @@ export function App(props: AppProps = {}) {
     async (credsUsername: string, credsPassword: string) => {
       const api = apiRef.current;
       if (!api) {
-        dispatch({
-          type: "FAIL",
-          payload: { message: "Session is not initialized." },
+        failWith(new Error("Session is not initialized."), {
+          fallbackCode: "internal_error",
         });
         return;
       }
       const site = siteRef.current;
       if (!site) {
-        dispatch({
-          type: "FAIL",
-          payload: { message: "Choose a provider before continuing." },
+        failWith(new Error("Choose a provider before continuing."), {
+          fallbackCode: "internal_error",
         });
         return;
       }
@@ -265,11 +298,13 @@ export function App(props: AppProps = {}) {
         await handleConnectResponse(api, response);
       } catch (err) {
         const message = (err as Error).message || "Connection failed.";
-        dispatch({ type: "FAIL", payload: { message } });
-        emit("ERROR", { error: message, site });
+        failWith(err instanceof Error ? err : new Error(message), {
+          fallbackCode: "network_error",
+          site,
+        });
       }
     },
-    [emit, encryptFn],
+    [emit, encryptFn, failWith],
   );
 
   const handleConnectResponse = useCallback(
@@ -323,16 +358,16 @@ export function App(props: AppProps = {}) {
           (terminal.status === "timeout"
             ? "The connection timed out before the provider completed the flow."
             : "The connection could not be completed.");
-        dispatch({ type: "FAIL", payload: { message } });
-        emit("ERROR", { error: message, site: siteRef.current });
+        const fallback: LinkErrorCode =
+          terminal.status === "timeout" ? "mfa_timeout" : "internal_error";
+        failWith(new Error(message), { fallbackCode: fallback });
         return;
       }
       const message =
         response.error || response.detail || `Unexpected status: ${response.status}`;
-      dispatch({ type: "FAIL", payload: { message } });
-      emit("ERROR", { error: message, site: siteRef.current });
+      failWith(new Error(message), { fallbackCode: "internal_error" });
     },
-    [emit, pollFn],
+    [emit, failWith, pollFn],
   );
 
   const finishSuccess = useCallback(
@@ -408,10 +443,11 @@ export function App(props: AppProps = {}) {
       await handleConnectResponse(api, response);
     } catch (err) {
       const message = (err as Error).message || "Verification failed.";
-      dispatch({ type: "FAIL", payload: { message } });
-      emit("ERROR", { error: message, site: siteRef.current });
+      failWith(err instanceof Error ? err : new Error(message), {
+        fallbackCode: "mfa_timeout",
+      });
     }
-  }, [emit, handleConnectResponse, mfaSchemaEntry, mfaValues]);
+  }, [emit, failWith, handleConnectResponse, mfaSchemaEntry, mfaValues]);
 
   const consent = useMemo(() => CONSENT_BULLETS, []);
 
@@ -654,15 +690,55 @@ export function App(props: AppProps = {}) {
         className={state.step === "error" ? "link-step active" : "link-step"}
         role="region"
         aria-label="Connection failed"
+        data-error-code={state.error?.code ?? "internal_error"}
       >
-        <p id="error-message">{state.error?.message ?? ""}</p>
-        <button
-          id="retry-btn"
-          type="button"
-          onClick={() => dispatch({ type: "BACK_TO_PICKER" })}
-        >
-          Try again
-        </button>
+        {(() => {
+          const remediation = remediationFor(state.error?.code);
+          const handleAction = (action: RemediationAction) => {
+            if (action === "retry") {
+              dispatch({ type: "BACK_TO_PICKER" });
+            } else if (action === "back_to_picker") {
+              dispatch({ type: "BACK_TO_PICKER" });
+            } else if (action === "contact_support") {
+              emit("SUPPORT_REQUESTED", {
+                error_code: state.error?.code ?? "internal_error",
+              });
+            } else if (action === "exit") {
+              emit("EXIT", {
+                reason: "user_exit",
+                error_code: state.error?.code ?? null,
+              });
+            }
+          };
+          return (
+            <>
+              <h2 id="error-title">{remediation.title}</h2>
+              <p id="error-description">{remediation.description}</p>
+              <p id="error-message" className="sr-only">
+                {state.error?.message ?? ""}
+              </p>
+              <div className="error-actions">
+                <button
+                  id="retry-btn"
+                  type="button"
+                  onClick={() => handleAction(remediation.primary_action)}
+                >
+                  {remediation.primary_cta}
+                </button>
+                {remediation.secondary_cta && remediation.secondary_action ? (
+                  <button
+                    id="error-secondary-btn"
+                    type="button"
+                    className="secondary"
+                    onClick={() => handleAction(remediation.secondary_action!)}
+                  >
+                    {remediation.secondary_cta}
+                  </button>
+                ) : null}
+              </div>
+            </>
+          );
+        })()}
       </section>
     </main>
   );

--- a/frontend-next/src/api.ts
+++ b/frontend-next/src/api.ts
@@ -107,9 +107,11 @@ export interface EncryptedCredentials {
 }
 
 export class ApiError extends Error {
-  constructor(message: string, readonly status: number) {
+  public readonly error_code?: string;
+  constructor(message: string, readonly status: number, error_code?: string) {
     super(message);
     this.name = "ApiError";
+    this.error_code = error_code;
   }
 }
 
@@ -133,10 +135,10 @@ async function request<T>(
   const text = await response.text();
   const payload = text ? (JSON.parse(text) as unknown) : ({} as unknown);
   if (!response.ok) {
-    const record = payload as { detail?: string; error?: string };
+    const record = payload as { detail?: string; error?: string; error_code?: string };
     const message =
       record.detail || record.error || response.statusText || "Request failed";
-    throw new ApiError(message, response.status);
+    throw new ApiError(message, response.status, record.error_code);
   }
   return payload as T;
 }

--- a/frontend-next/src/errorTaxonomy.test.ts
+++ b/frontend-next/src/errorTaxonomy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  REMEDIATIONS,
+  classifyError,
+  classifyMessage,
+  remediationFor,
+} from "./errorTaxonomy";
+
+describe("errorTaxonomy", () => {
+  it("ships a remediation for every code", () => {
+    const keys = Object.keys(REMEDIATIONS);
+    expect(keys).toHaveLength(7);
+    for (const remediation of Object.values(REMEDIATIONS)) {
+      expect(remediation.title).toBeTruthy();
+      expect(remediation.description).toBeTruthy();
+      expect(remediation.primary_cta).toBeTruthy();
+      expect(remediation.primary_action).toBeTruthy();
+    }
+  });
+
+  it("remediationFor falls back to internal_error for unknown codes", () => {
+    const fallback = remediationFor("does_not_exist" as never);
+    expect(fallback).toBe(REMEDIATIONS.internal_error);
+  });
+
+  it("remediationFor handles undefined", () => {
+    expect(remediationFor(undefined)).toBe(REMEDIATIONS.internal_error);
+  });
+
+  it("classifyError reads error_code off the error instance", () => {
+    const err = Object.assign(new Error("anything"), {
+      error_code: "invalid_credentials",
+    });
+    expect(classifyError(err)).toBe("invalid_credentials");
+  });
+
+  it("classifyError falls back to message heuristics", () => {
+    expect(classifyError(new Error("Invalid credentials provided"))).toBe(
+      "invalid_credentials",
+    );
+    expect(classifyError(new Error("Network offline"))).toBe("network_error");
+    expect(classifyError(new Error("MFA timeout reached"))).toBe("mfa_timeout");
+    expect(classifyError(new Error("Rate limit exceeded"))).toBe("rate_limited");
+    expect(classifyError(new Error("Something random"))).toBe("internal_error");
+  });
+
+  it("classifyMessage handles empty inputs", () => {
+    expect(classifyMessage(undefined)).toBe("internal_error");
+    expect(classifyMessage("")).toBe("internal_error");
+  });
+});

--- a/frontend-next/src/errorTaxonomy.ts
+++ b/frontend-next/src/errorTaxonomy.ts
@@ -1,0 +1,161 @@
+/**
+ * Mirror of `src/error_taxonomy.py` for the hosted-link frontend
+ * (issue #55). The backend also exposes this at `/link/error-taxonomy`;
+ * we ship a static copy so the UI can render remediation screens
+ * before the first network round-trip.
+ *
+ * Keep in sync with the Python source of truth.
+ */
+
+export type LinkErrorCode =
+  | "invalid_credentials"
+  | "mfa_timeout"
+  | "institution_down"
+  | "rate_limited"
+  | "unsupported_site"
+  | "network_error"
+  | "internal_error";
+
+export type RemediationAction =
+  | "retry"
+  | "back_to_picker"
+  | "exit"
+  | "contact_support";
+
+export interface Remediation {
+  readonly title: string;
+  readonly description: string;
+  readonly primary_cta: string;
+  readonly primary_action: RemediationAction;
+  readonly secondary_cta: string | null;
+  readonly secondary_action: RemediationAction | null;
+  readonly retryable: boolean;
+}
+
+export const REMEDIATIONS: Readonly<Record<LinkErrorCode, Remediation>> = {
+  invalid_credentials: {
+    title: "We couldn't sign you in",
+    description:
+      "The username or password doesn't match what your provider has on file. Double-check your credentials and try again, or reset them with your provider.",
+    primary_cta: "Try again",
+    primary_action: "retry",
+    secondary_cta: "Choose a different provider",
+    secondary_action: "back_to_picker",
+    retryable: true,
+  },
+  mfa_timeout: {
+    title: "Verification timed out",
+    description:
+      "We didn't receive your verification code in time. You can request a new code and try again.",
+    primary_cta: "Start over",
+    primary_action: "retry",
+    secondary_cta: "Choose a different provider",
+    secondary_action: "back_to_picker",
+    retryable: true,
+  },
+  institution_down: {
+    title: "Your provider is temporarily unavailable",
+    description:
+      "Their systems aren't responding right now. This usually resolves within a few minutes — try again shortly, or pick a different provider.",
+    primary_cta: "Try again",
+    primary_action: "retry",
+    secondary_cta: "Choose a different provider",
+    secondary_action: "back_to_picker",
+    retryable: true,
+  },
+  rate_limited: {
+    title: "Too many attempts",
+    description:
+      "We're pausing briefly to protect your account. Please wait a moment before trying again.",
+    primary_cta: "Try again in a moment",
+    primary_action: "retry",
+    secondary_cta: "Exit",
+    secondary_action: "exit",
+    retryable: true,
+  },
+  unsupported_site: {
+    title: "Provider not supported yet",
+    description:
+      "We don't have an integration for this provider. Pick a different one, or let us know what you'd like us to add.",
+    primary_cta: "Choose a different provider",
+    primary_action: "back_to_picker",
+    secondary_cta: "Contact support",
+    secondary_action: "contact_support",
+    retryable: false,
+  },
+  network_error: {
+    title: "Connection interrupted",
+    description:
+      "We lost the connection to your provider. Check your internet connection and try again.",
+    primary_cta: "Try again",
+    primary_action: "retry",
+    secondary_cta: "Choose a different provider",
+    secondary_action: "back_to_picker",
+    retryable: true,
+  },
+  internal_error: {
+    title: "Something went wrong on our end",
+    description:
+      "An unexpected error occurred while setting up your secure connection. Please try again, and contact support if this keeps happening.",
+    primary_cta: "Try again",
+    primary_action: "retry",
+    secondary_cta: "Contact support",
+    secondary_action: "contact_support",
+    retryable: true,
+  },
+};
+
+export function remediationFor(code: LinkErrorCode | string | null | undefined): Remediation {
+  if (code && code in REMEDIATIONS) {
+    return REMEDIATIONS[code as LinkErrorCode];
+  }
+  return REMEDIATIONS.internal_error;
+}
+
+/**
+ * Best-effort classification of a caught Error into a structured code.
+ * Prefers an explicit code embedded on the error (e.g. from a fetch
+ * response body), then falls back to simple heuristics.
+ */
+export function classifyError(error: unknown): LinkErrorCode {
+  if (error && typeof error === "object") {
+    const maybeCode = (error as { error_code?: unknown }).error_code;
+    if (typeof maybeCode === "string" && maybeCode in REMEDIATIONS) {
+      return maybeCode as LinkErrorCode;
+    }
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string") {
+      return classifyMessage(message);
+    }
+  }
+  if (typeof error === "string") {
+    return classifyMessage(error);
+  }
+  return "internal_error";
+}
+
+export function classifyMessage(message: string | null | undefined): LinkErrorCode {
+  if (!message) {
+    return "internal_error";
+  }
+  const lower = message.toLowerCase();
+  if (lower.includes("credential") || lower.includes("authentication")) {
+    return "invalid_credentials";
+  }
+  if (lower.includes("mfa") && lower.includes("timeout")) {
+    return "mfa_timeout";
+  }
+  if (lower.includes("rate") && lower.includes("limit")) {
+    return "rate_limited";
+  }
+  if (lower.includes("unsupported") || lower.includes("not supported")) {
+    return "unsupported_site";
+  }
+  if (lower.includes("network") || lower.includes("offline") || lower.includes("timeout")) {
+    return "network_error";
+  }
+  if (lower.includes("unavailable") || lower.includes("down")) {
+    return "institution_down";
+  }
+  return "internal_error";
+}

--- a/src/app.py
+++ b/src/app.py
@@ -415,11 +415,21 @@ else:
 @app.exception_handler(PlaidifyError)
 async def plaidify_error_handler(request: Request, exc: PlaidifyError) -> JSONResponse:
     """Catch PlaidifyError subclasses and return structured JSON."""
+    code = exc.error_code.value if hasattr(exc.error_code, "value") else str(exc.error_code)
     logger.error(
         exc.message,
-        extra={"extra_data": {"status_code": exc.status_code, "path": request.url.path}},
+        extra={
+            "extra_data": {
+                "status_code": exc.status_code,
+                "path": request.url.path,
+                "error_code": code,
+            }
+        },
     )
-    return JSONResponse(status_code=exc.status_code, content={"error": exc.message})
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": exc.message, "error_code": code},
+    )
 
 
 for router in (

--- a/src/error_taxonomy.py
+++ b/src/error_taxonomy.py
@@ -1,0 +1,192 @@
+"""
+Shared error taxonomy for the hosted Link flow (issue #55).
+
+This module is the single source of truth for structured error codes
+surfaced to the hosted Link UI, SDKs, and downstream consumers (EXIT /
+ERROR bridge events). Each code carries remediation copy and CTA
+targets so the frontend can render consistent recovery screens without
+hardcoded strings spread across the codebase.
+
+The companion TypeScript mirror lives in
+`frontend-next/src/errorTaxonomy.ts` — keep the two in sync.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class LinkErrorCode(str, Enum):
+    """Canonical hosted-link error codes."""
+
+    INVALID_CREDENTIALS = "invalid_credentials"
+    MFA_TIMEOUT = "mfa_timeout"
+    INSTITUTION_DOWN = "institution_down"
+    RATE_LIMITED = "rate_limited"
+    UNSUPPORTED_SITE = "unsupported_site"
+    NETWORK_ERROR = "network_error"
+    INTERNAL_ERROR = "internal_error"
+
+
+@dataclass(frozen=True)
+class Remediation:
+    """Remediation copy + CTAs for a given error code."""
+
+    title: str
+    description: str
+    primary_cta: str
+    primary_action: str  # "retry" | "back_to_picker" | "exit" | "contact_support"
+    secondary_cta: str | None
+    secondary_action: str | None
+    retryable: bool
+
+
+REMEDIATIONS: dict[LinkErrorCode, Remediation] = {
+    LinkErrorCode.INVALID_CREDENTIALS: Remediation(
+        title="We couldn't sign you in",
+        description=(
+            "The username or password doesn't match what your provider has "
+            "on file. Double-check your credentials and try again, or reset "
+            "them with your provider."
+        ),
+        primary_cta="Try again",
+        primary_action="retry",
+        secondary_cta="Choose a different provider",
+        secondary_action="back_to_picker",
+        retryable=True,
+    ),
+    LinkErrorCode.MFA_TIMEOUT: Remediation(
+        title="Verification timed out",
+        description=(
+            "We didn't receive your verification code in time. You can "
+            "request a new code and try again."
+        ),
+        primary_cta="Start over",
+        primary_action="retry",
+        secondary_cta="Choose a different provider",
+        secondary_action="back_to_picker",
+        retryable=True,
+    ),
+    LinkErrorCode.INSTITUTION_DOWN: Remediation(
+        title="Your provider is temporarily unavailable",
+        description=(
+            "Their systems aren't responding right now. This usually "
+            "resolves within a few minutes — try again shortly, or pick a "
+            "different provider."
+        ),
+        primary_cta="Try again",
+        primary_action="retry",
+        secondary_cta="Choose a different provider",
+        secondary_action="back_to_picker",
+        retryable=True,
+    ),
+    LinkErrorCode.RATE_LIMITED: Remediation(
+        title="Too many attempts",
+        description=(
+            "We're pausing briefly to protect your account. Please wait a "
+            "moment before trying again."
+        ),
+        primary_cta="Try again in a moment",
+        primary_action="retry",
+        secondary_cta="Exit",
+        secondary_action="exit",
+        retryable=True,
+    ),
+    LinkErrorCode.UNSUPPORTED_SITE: Remediation(
+        title="Provider not supported yet",
+        description=(
+            "We don't have an integration for this provider. Pick a "
+            "different one, or let us know what you'd like us to add."
+        ),
+        primary_cta="Choose a different provider",
+        primary_action="back_to_picker",
+        secondary_cta="Contact support",
+        secondary_action="contact_support",
+        retryable=False,
+    ),
+    LinkErrorCode.NETWORK_ERROR: Remediation(
+        title="Connection interrupted",
+        description=(
+            "We lost the connection to your provider. Check your internet "
+            "connection and try again."
+        ),
+        primary_cta="Try again",
+        primary_action="retry",
+        secondary_cta="Choose a different provider",
+        secondary_action="back_to_picker",
+        retryable=True,
+    ),
+    LinkErrorCode.INTERNAL_ERROR: Remediation(
+        title="Something went wrong on our end",
+        description=(
+            "An unexpected error occurred while setting up your secure "
+            "connection. Please try again, and contact support if this "
+            "keeps happening."
+        ),
+        primary_cta="Try again",
+        primary_action="retry",
+        secondary_cta="Contact support",
+        secondary_action="contact_support",
+        retryable=True,
+    ),
+}
+
+
+def remediation_for(code: LinkErrorCode | str) -> Remediation:
+    """Resolve a remediation entry by enum member or raw string."""
+    if isinstance(code, LinkErrorCode):
+        return REMEDIATIONS[code]
+    try:
+        return REMEDIATIONS[LinkErrorCode(code)]
+    except ValueError:
+        return REMEDIATIONS[LinkErrorCode.INTERNAL_ERROR]
+
+
+def serialize_taxonomy() -> dict[str, Any]:
+    """Wire-format suitable for /link/error-taxonomy and SDKs."""
+    return {
+        "version": 1,
+        "codes": [
+            {
+                "code": code.value,
+                "title": remediation.title,
+                "description": remediation.description,
+                "primary_cta": remediation.primary_cta,
+                "primary_action": remediation.primary_action,
+                "secondary_cta": remediation.secondary_cta,
+                "secondary_action": remediation.secondary_action,
+                "retryable": remediation.retryable,
+            }
+            for code, remediation in REMEDIATIONS.items()
+        ],
+    }
+
+
+def classify_exception(exc: BaseException) -> LinkErrorCode:
+    """Map a known exception type onto a structured error code.
+
+    Callers should prefer the exception's own `error_code` attribute (on
+    `PlaidifyError`); this helper is for untyped exceptions bubbled up
+    from third-party code.
+    """
+    # Avoid a hard import cycle — resolve lazily.
+    from src.exceptions import PlaidifyError
+
+    if isinstance(exc, PlaidifyError):
+        code = getattr(exc, "error_code", None)
+        if isinstance(code, LinkErrorCode):
+            return code
+        if isinstance(code, str):
+            try:
+                return LinkErrorCode(code)
+            except ValueError:
+                pass
+
+    name = type(exc).__name__.lower()
+    if "timeout" in name:
+        return LinkErrorCode.NETWORK_ERROR
+    if "connection" in name or "network" in name:
+        return LinkErrorCode.NETWORK_ERROR
+    return LinkErrorCode.INTERNAL_ERROR

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -6,9 +6,15 @@ This allows callers to catch all Plaidify errors with a single except clause,
 or catch specific sub-types for fine-grained handling.
 """
 
+from src.error_taxonomy import LinkErrorCode
+
 
 class PlaidifyError(Exception):
     """Base exception for all Plaidify errors."""
+
+    #: Structured hosted-link error code (#55). Subclasses override this
+    #: class attribute; the global HTTP handler surfaces it to the UI.
+    error_code: LinkErrorCode = LinkErrorCode.INTERNAL_ERROR
 
     def __init__(self, message: str = "An unexpected error occurred.", status_code: int = 500):
         self.message = message
@@ -21,6 +27,8 @@ class PlaidifyError(Exception):
 
 class BlueprintNotFoundError(PlaidifyError):
     """Raised when a connector blueprint cannot be found for the requested site."""
+
+    error_code = LinkErrorCode.UNSUPPORTED_SITE
 
     def __init__(self, site: str):
         super().__init__(
@@ -46,6 +54,8 @@ class BlueprintValidationError(PlaidifyError):
 
 class ConnectionFailedError(PlaidifyError):
     """Raised when the engine fails to establish a connection to the target site."""
+
+    error_code = LinkErrorCode.NETWORK_ERROR
 
     def __init__(self, site: str, detail: str = ""):
         msg = f"Connection failed for site: {site}"
@@ -84,6 +94,8 @@ class ConcurrentAccessError(PlaidifyError):
 class AuthenticationError(PlaidifyError):
     """Raised when login credentials are rejected by the target site."""
 
+    error_code = LinkErrorCode.INVALID_CREDENTIALS
+
     def __init__(self, site: str):
         super().__init__(
             message=f"Authentication failed for site: {site}. Check your credentials.",
@@ -108,6 +120,8 @@ class MFARequiredError(PlaidifyError):
 class SiteUnavailableError(PlaidifyError):
     """Raised when the target site is unreachable or returns an error."""
 
+    error_code = LinkErrorCode.INSTITUTION_DOWN
+
     def __init__(self, site: str, detail: str = ""):
         msg = f"Site unavailable: {site}"
         if detail:
@@ -118,6 +132,8 @@ class SiteUnavailableError(PlaidifyError):
 
 class RateLimitedError(PlaidifyError):
     """Raised when the target site or Plaidify itself is rate-limiting requests."""
+
+    error_code = LinkErrorCode.RATE_LIMITED
 
     def __init__(self, retry_after: int = 60):
         super().__init__(

--- a/src/routers/system.py
+++ b/src/routers/system.py
@@ -13,6 +13,7 @@ from src.config import get_settings
 from src.core.browser_pool import get_browser_pool
 from src.database import User, get_db
 from src.dependencies import get_current_user, get_current_user_or_api_key
+from src.error_taxonomy import serialize_taxonomy
 from src.logging_config import get_logger
 from src.organization_catalog import get_organization_by_id, get_organization_summary, search_organizations
 
@@ -165,6 +166,16 @@ async def organization_detail(organization_id: str):
     if entry is None:
         raise HTTPException(status_code=404, detail="Organization not found.")
     return entry
+
+
+@router.get("/link/error-taxonomy")
+async def link_error_taxonomy():
+    """Return the shared hosted-link error taxonomy (issue #55).
+
+    Shared between server, SDKs, and the hosted Link page so that error
+    codes, remediation copy, and CTAs stay consistent across surfaces.
+    """
+    return serialize_taxonomy()
 
 
 # ── Blueprint Discovery ──────────────────────────────────────────────────────

--- a/tests/test_error_taxonomy.py
+++ b/tests/test_error_taxonomy.py
@@ -1,0 +1,79 @@
+"""Tests for the hosted-link error taxonomy (issue #55)."""
+
+from fastapi.testclient import TestClient
+
+from src.app import app
+from src.error_taxonomy import (
+    REMEDIATIONS,
+    LinkErrorCode,
+    classify_exception,
+    remediation_for,
+    serialize_taxonomy,
+)
+from src.exceptions import (
+    AuthenticationError,
+    BlueprintNotFoundError,
+    ConnectionFailedError,
+    RateLimitedError,
+    SiteUnavailableError,
+)
+
+
+def test_every_code_has_a_remediation() -> None:
+    for code in LinkErrorCode:
+        assert code in REMEDIATIONS
+        entry = REMEDIATIONS[code]
+        assert entry.title and entry.description and entry.primary_cta
+        assert entry.primary_action in {
+            "retry",
+            "back_to_picker",
+            "exit",
+            "contact_support",
+        }
+
+
+def test_remediation_for_accepts_strings_and_defaults() -> None:
+    assert remediation_for("invalid_credentials") is REMEDIATIONS[LinkErrorCode.INVALID_CREDENTIALS]
+    # Unknown codes degrade gracefully to internal_error.
+    assert remediation_for("not_a_code").title == REMEDIATIONS[LinkErrorCode.INTERNAL_ERROR].title
+
+
+def test_classify_exception_maps_known_plaidify_errors() -> None:
+    assert classify_exception(AuthenticationError("demo")) == LinkErrorCode.INVALID_CREDENTIALS
+    assert classify_exception(SiteUnavailableError("demo")) == LinkErrorCode.INSTITUTION_DOWN
+    assert classify_exception(RateLimitedError()) == LinkErrorCode.RATE_LIMITED
+    assert classify_exception(BlueprintNotFoundError("demo")) == LinkErrorCode.UNSUPPORTED_SITE
+    assert classify_exception(ConnectionFailedError("demo")) == LinkErrorCode.NETWORK_ERROR
+    assert classify_exception(RuntimeError("boom")) == LinkErrorCode.INTERNAL_ERROR
+
+
+def test_link_error_taxonomy_endpoint_exposes_all_codes() -> None:
+    client = TestClient(app)
+    response = client.get("/link/error-taxonomy")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["version"] == 1
+    codes = {entry["code"] for entry in body["codes"]}
+    assert codes == {member.value for member in LinkErrorCode}
+
+
+def test_plaidify_error_handler_includes_error_code() -> None:
+    # We need an endpoint that raises AuthenticationError. Use a handler
+    # via FastAPI dependency injection on an ad-hoc route.
+    from src.app import app as fastapi_app
+
+    @fastapi_app.get("/_test/auth-fail")
+    def _auth_fail() -> None:
+        raise AuthenticationError("demo-site")
+
+    client = TestClient(fastapi_app)
+    response = client.get("/_test/auth-fail")
+    assert response.status_code == 401
+    body = response.json()
+    assert body["error_code"] == LinkErrorCode.INVALID_CREDENTIALS.value
+
+
+def test_serialize_taxonomy_is_deterministic() -> None:
+    first = serialize_taxonomy()
+    second = serialize_taxonomy()
+    assert first == second


### PR DESCRIPTION
Closes #55.

## Summary
Introduces a shared error taxonomy for the hosted-link flow so the client and server agree on recoverable vs terminal failure states, and replaces the generic error screen with a remediation UI driven by structured error codes.

## Backend
- `src/error_taxonomy.py` — new single source of truth. Defines `LinkErrorCode` (7 codes), a frozen `Remediation` dataclass, `REMEDIATIONS` mapping, `remediation_for()`, `serialize_taxonomy()`, and `classify_exception()`.
- `PlaidifyError` gains `error_code` class attribute; `BlueprintNotFoundError`, `ConnectionFailedError`, `AuthenticationError`, `SiteUnavailableError`, `RateLimitedError` map to structured codes.
- `app.py` PlaidifyError handler serializes `error_code` in the JSON body and structured log.
- New `GET /link/error-taxonomy` endpoint so clients can fetch the live catalog.

## Frontend
- `frontend-next/src/errorTaxonomy.ts` — TypeScript mirror with `classifyError`, `classifyMessage`, and `remediationFor`.
- `ApiError` now captures `error_code` off response bodies.
- `App.tsx` adds a `failWith()` helper that classifies errors and threads `code` through `FAIL` dispatches, `ERROR` bridge events, and the `EXIT` payload.
- `#step-error` section renders remediation title/description and dynamic primary/secondary CTAs keyed off `state.error.code`, while preserving `#error-message` and `#retry-btn` DOM hooks.

## Tests
- `tests/test_error_taxonomy.py` (6 tests, all pass)
- `frontend-next/src/errorTaxonomy.test.ts` (6 tests, all pass)
- Full frontend suite: 58/58 passing. Full backend smoke (`test_error_taxonomy`, `test_hosted_link_e2e`, `test_main`): 12/12 passing.