### PR TITLE
feat(link): i18n catalogs + dark-mode theme querystring (#57)

### DIFF
--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -30,20 +30,25 @@ import {
 } from "./errorTaxonomy";
 import { EventDelivery, postBridgeEvent } from "./events";
 import {
+  DEFAULT_LOCALE,
+  type Locale,
+  type Messages,
+  getMessages,
+  resolveLocale,
+} from "./i18n";
+import {
   flowReducer,
   initialFlowState,
   type FlowState,
   type Institution,
 } from "./state";
 
-const CONSENT_BULLETS: readonly string[] = [
-  "Open a secure browser session with the provider you choose.",
-  "Encrypt your sign-in details before they leave this window.",
-  "Return a secure completion back to your app when verification finishes.",
-];
-
-const SUCCESS_MESSAGE =
-  "Your secure connection is complete. Return to your app to finish setup.";
+// NOTE: The canonical English copy for the E2E DOM contract now lives
+// in `./i18n` (the `en-US` catalog). Keep the following strings stable
+// when evolving that catalog: the third consent bullet must read
+// "Return a secure completion back to your app when verification
+// finishes.", the success message must contain "Return to your app",
+// and the public-token label must be "PUBLIC TOKEN".
 
 type EncryptCredentialsFn = typeof defaultEncryptCredentials;
 type PollLinkSessionFn = (options: PollOptions) => Promise<LinkSessionStatus>;
@@ -68,6 +73,8 @@ export interface AppProps {
   ) => EventDelivery | null;
   /** Default institution list (used before the first search completes). */
   readonly seedInstitutions?: readonly Organization[];
+  /** Override the negotiated UI locale (tests / storybook). */
+  readonly locale?: Locale;
 }
 
 export function App(props: AppProps = {}) {
@@ -103,6 +110,19 @@ export function App(props: AppProps = {}) {
   const stepHeadingRef = useRef<HTMLElement | null>(null);
   const previousStepRef = useRef<string>(state.step);
   const [liveAnnouncement, setLiveAnnouncement] = useState("");
+
+  const locale: Locale =
+    props.locale ??
+    (typeof window !== "undefined"
+      ? resolveLocale({
+          search: window.location.search,
+          navigatorLanguages:
+            typeof navigator !== "undefined"
+              ? [...(navigator.languages ?? [navigator.language ?? "en-US"])]
+              : undefined,
+        })
+      : DEFAULT_LOCALE);
+  const messages: Messages = useMemo(() => getMessages(locale), [locale]);
 
   const encryptFn = props.encryptCredentials ?? defaultEncryptCredentials;
   const pollFn = props.pollLinkSession ?? defaultPollLinkSession;
@@ -238,17 +258,17 @@ export function App(props: AppProps = {}) {
       }
     }
     const announcements: Record<string, string> = {
-      select: "Choose your provider to get started.",
-      credentials: "Enter your credentials for the selected provider.",
-      connecting: "Connecting to your provider.",
-      mfa: "Additional verification required.",
-      success: "Connection successful.",
+      select: messages.live_select,
+      credentials: messages.live_credentials,
+      connecting: messages.live_connecting,
+      mfa: messages.live_mfa,
+      success: messages.live_success,
       error: state.error?.message
-        ? `Connection failed: ${state.error.message}`
-        : "Connection failed.",
+        ? `${messages.live_error} ${state.error.message}`
+        : messages.live_error,
     };
     setLiveAnnouncement(announcements[state.step] ?? "");
-  }, [state.step, state.error?.message]);
+  }, [state.step, state.error?.message, messages]);
 
   const failWith = useCallback(
     (err: unknown, options: { fallbackCode?: LinkErrorCode; site?: string | null } = {}) => {
@@ -423,7 +443,7 @@ export function App(props: AppProps = {}) {
       const publicToken = resolved.public_token ?? "";
       dispatch({
         type: "SUCCEED",
-        payload: { accessToken: publicToken, summary: SUCCESS_MESSAGE },
+        payload: { accessToken: publicToken, summary: messages.success_message },
       });
       emit("CONNECTED", {
         job_id: resolved.job_id ?? null,
@@ -431,7 +451,7 @@ export function App(props: AppProps = {}) {
         site: siteRef.current,
       });
     },
-    [emit],
+    [emit, messages],
   );
 
   const onSubmitCredentials = useCallback(() => {
@@ -483,10 +503,10 @@ export function App(props: AppProps = {}) {
     }
   }, [emit, failWith, handleConnectResponse, mfaSchemaEntry, mfaValues]);
 
-  const consent = useMemo(() => CONSENT_BULLETS, []);
+  const consent = useMemo(() => messages.consent_bullets, [messages]);
 
   return (
-    <main role="main" aria-label="Plaidify Link" className="plaidify-link">
+    <main role="main" aria-label="Plaidify Link" className="plaidify-link" lang={locale}>
       <div
         id="link-live-region"
         role="status"
@@ -500,7 +520,7 @@ export function App(props: AppProps = {}) {
         id="step-select"
         className={state.step === "select" ? "link-step active" : "link-step"}
         role="region"
-        aria-label="Select your provider"
+        aria-label={messages.step_select_heading}
       >
         <h2
           id="step-select-heading"
@@ -510,17 +530,17 @@ export function App(props: AppProps = {}) {
           }}
           tabIndex={-1}
         >
-          Select your provider
+          {messages.step_select_heading}
         </h2>
         <label className="sr-only" htmlFor="institution-search">
-          Search providers
+          {messages.search_label}
         </label>
         <input
           id="institution-search"
           type="text"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search providers"
+          placeholder={messages.search_placeholder}
           autoComplete="off"
         />
         {searchError ? (
@@ -595,7 +615,7 @@ export function App(props: AppProps = {}) {
         id="step-credentials"
         className={state.step === "credentials" ? "link-step active" : "link-step"}
         role="region"
-        aria-label="Enter your credentials"
+        aria-label={messages.step_credentials_heading}
         style={
           state.institution?.primary_color
             ? ({
@@ -663,7 +683,7 @@ export function App(props: AppProps = {}) {
           }}
         />
         <button id="connect-btn" type="button" onClick={onSubmitCredentials}>
-          {credentialSchema.submit_label ?? "Continue"}
+          {credentialSchema.submit_label ?? messages.continue_cta}
         </button>
       </section>
 
@@ -671,7 +691,7 @@ export function App(props: AppProps = {}) {
         id="step-connecting"
         className={state.step === "connecting" ? "link-step active" : "link-step"}
         role="region"
-        aria-label="Connecting"
+        aria-label={messages.step_connecting_heading}
       >
         <p
           role="status"
@@ -680,7 +700,7 @@ export function App(props: AppProps = {}) {
           }}
           tabIndex={-1}
         >
-          Creating your secure session&hellip;
+          {messages.step_connecting_body}
         </p>
       </section>
 
@@ -688,7 +708,7 @@ export function App(props: AppProps = {}) {
         id="step-mfa"
         className={state.step === "mfa" ? "link-step active" : "link-step"}
         role="region"
-        aria-label="Finish verification"
+        aria-label={messages.step_mfa_heading}
         style={
           state.institution?.primary_color
             ? ({
@@ -752,7 +772,7 @@ export function App(props: AppProps = {}) {
           }}
         />
         <button id="mfa-submit-btn" type="button" onClick={() => void onSubmitMfa()}>
-          {mfaSchemaEntry.submit_label ?? "Verify and continue"}
+          {mfaSchemaEntry.submit_label ?? messages.verify_cta}
         </button>
       </section>
 
@@ -760,7 +780,7 @@ export function App(props: AppProps = {}) {
         id="step-success"
         className={state.step === "success" ? "link-step active" : "link-step"}
         role="region"
-        aria-label="Connection successful"
+        aria-label={messages.step_success_heading}
       >
         <p
           id="success-message"
@@ -769,12 +789,12 @@ export function App(props: AppProps = {}) {
           }}
           tabIndex={-1}
         >
-          {state.success?.summary ?? SUCCESS_MESSAGE}
+          {state.success?.summary ?? messages.success_message}
         </p>
         <div id="access-token-display">
           {state.success?.accessToken ? (
             <div className="reference-row">
-              <span className="reference-label">PUBLIC TOKEN</span>
+              <span className="reference-label">{messages.public_token_label}</span>
               <span className="reference-value">{state.success.accessToken}</span>
             </div>
           ) : null}
@@ -785,7 +805,7 @@ export function App(props: AppProps = {}) {
         id="step-error"
         className={state.step === "error" ? "link-step active" : "link-step"}
         role="region"
-        aria-label="Connection failed"
+        aria-label={messages.step_error_heading}
         aria-live="assertive"
         data-error-code={state.error?.code ?? "internal_error"}
       >

--- a/frontend-next/src/i18n.test.ts
+++ b/frontend-next/src/i18n.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_LOCALE,
+  MESSAGES,
+  SUPPORTED_LOCALES,
+  applyTheme,
+  getMessages,
+  resolveLocale,
+  resolveTheme,
+} from "./i18n";
+
+describe("i18n", () => {
+  it("ships a catalog for every supported locale", () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      const messages = MESSAGES[locale];
+      expect(messages).toBeDefined();
+      expect(messages.step_select_heading.length).toBeGreaterThan(0);
+      expect(messages.consent_bullets.length).toBe(3);
+    }
+  });
+
+  it("en-US keeps the E2E contract strings stable", () => {
+    expect(MESSAGES["en-US"].consent_bullets[2]).toBe(
+      "Return a secure completion back to your app when verification finishes.",
+    );
+    expect(MESSAGES["en-US"].success_message).toContain("Return to your app");
+    expect(MESSAGES["en-US"].public_token_label).toBe("PUBLIC TOKEN");
+  });
+
+  it("getMessages falls back to the default locale", () => {
+    expect(getMessages("does-not-exist")).toBe(MESSAGES[DEFAULT_LOCALE]);
+    expect(getMessages(undefined)).toBe(MESSAGES[DEFAULT_LOCALE]);
+  });
+
+  it("resolveLocale prefers ?locale= querystring", () => {
+    expect(resolveLocale({ search: "?locale=fr-CA" })).toBe("fr-CA");
+    expect(resolveLocale({ search: "?locale=xx-YY" })).toBe(DEFAULT_LOCALE);
+  });
+
+  it("resolveLocale falls back to Accept-Language header", () => {
+    expect(
+      resolveLocale({ acceptLanguage: "fr-CA,fr;q=0.9,en;q=0.5" }),
+    ).toBe("fr-CA");
+    expect(
+      resolveLocale({ acceptLanguage: "de-DE,de;q=0.9" }),
+    ).toBe(DEFAULT_LOCALE);
+  });
+
+  it("resolveLocale matches by language prefix", () => {
+    expect(resolveLocale({ navigatorLanguages: ["fr"] })).toBe("fr-CA");
+    expect(resolveLocale({ navigatorLanguages: ["en"] })).toBe("en-US");
+  });
+
+  it("fr-CA translates consent bullets", () => {
+    const fr = MESSAGES["fr-CA"];
+    expect(fr.consent_bullets[0]).toContain("fournisseur");
+    expect(fr.public_token_label).toBe("JETON PUBLIC");
+  });
+
+  it("resolveTheme parses ?theme=", () => {
+    expect(resolveTheme("?theme=dark")).toBe("dark");
+    expect(resolveTheme("?theme=light")).toBe("light");
+    expect(resolveTheme("?foo=bar")).toBe("system");
+    expect(resolveTheme("")).toBe("system");
+    expect(resolveTheme(undefined)).toBe("system");
+  });
+
+  it("applyTheme sets data-theme on the target element", () => {
+    const root = document.createElement("html");
+    applyTheme("dark", root);
+    expect(root.getAttribute("data-theme")).toBe("dark");
+    applyTheme("light", root);
+    expect(root.getAttribute("data-theme")).toBe("light");
+    applyTheme("system", root);
+    expect(root.hasAttribute("data-theme")).toBe(false);
+  });
+});

--- a/frontend-next/src/i18n.ts
+++ b/frontend-next/src/i18n.ts
@@ -1,0 +1,210 @@
+/**
+ * Tiny message catalog + locale negotiation for the hosted-link app
+ * (issue #57). We deliberately hand-roll this rather than pulling in
+ * a full i18n framework — the string surface is small, the catalogs
+ * are shipped statically in the bundle, and we keep one source of
+ * truth (`en-US`) to satisfy the E2E DOM contract.
+ *
+ * Locale negotiation order (first match wins):
+ *   1. \`?locale=xx-YY\` querystring
+ *   2. \`Accept-Language\` (when provided, e.g. SSR or tests)
+ *   3. \`navigator.language(s)\`
+ *   4. Default \`en-US\`
+ */
+
+export type Locale = "en-US" | "en-CA" | "fr-CA";
+
+export const SUPPORTED_LOCALES: readonly Locale[] = ["en-US", "en-CA", "fr-CA"];
+export const DEFAULT_LOCALE: Locale = "en-US";
+
+export interface Messages {
+  readonly step_select_heading: string;
+  readonly step_credentials_heading: string;
+  readonly step_connecting_heading: string;
+  readonly step_connecting_body: string;
+  readonly step_mfa_heading: string;
+  readonly step_success_heading: string;
+  readonly step_error_heading: string;
+  readonly search_label: string;
+  readonly search_placeholder: string;
+  readonly consent_bullets: readonly string[];
+  readonly success_message: string;
+  readonly public_token_label: string;
+  readonly retry_cta: string;
+  readonly continue_cta: string;
+  readonly verify_cta: string;
+  readonly live_select: string;
+  readonly live_credentials: string;
+  readonly live_connecting: string;
+  readonly live_mfa: string;
+  readonly live_success: string;
+  readonly live_error: string;
+}
+
+// en-US is the source of truth. E2E assertions rely on exact English
+// copy for the consent bullet ("Return a secure completion back to
+// your app when verification finishes.") and the success message
+// ("Return to your app") — keep those wordings stable here.
+const EN_US: Messages = {
+  step_select_heading: "Select your provider",
+  step_credentials_heading: "Enter your credentials",
+  step_connecting_heading: "Connecting",
+  step_connecting_body: "Creating your secure session…",
+  step_mfa_heading: "Finish verification",
+  step_success_heading: "Connection successful",
+  step_error_heading: "Connection failed",
+  search_label: "Search providers",
+  search_placeholder: "Search providers",
+  consent_bullets: [
+    "Open a secure browser session with the provider you choose.",
+    "Encrypt your sign-in details before they leave this window.",
+    "Return a secure completion back to your app when verification finishes.",
+  ],
+  success_message:
+    "Your secure connection is complete. Return to your app to finish setup.",
+  public_token_label: "PUBLIC TOKEN",
+  retry_cta: "Try again",
+  continue_cta: "Continue",
+  verify_cta: "Verify and continue",
+  live_select: "Choose your provider to get started.",
+  live_credentials: "Enter your credentials for the selected provider.",
+  live_connecting: "Connecting to your provider.",
+  live_mfa: "Additional verification required.",
+  live_success: "Connection successful.",
+  live_error: "Connection failed.",
+};
+
+// en-CA currently mirrors en-US; kept as a distinct entry so future
+// Canadian-English tweaks (e.g. "organisation") can diverge cleanly.
+const EN_CA: Messages = EN_US;
+
+const FR_CA: Messages = {
+  step_select_heading: "Choisissez votre fournisseur",
+  step_credentials_heading: "Entrez vos identifiants",
+  step_connecting_heading: "Connexion en cours",
+  step_connecting_body: "Création de votre session sécurisée…",
+  step_mfa_heading: "Terminez la vérification",
+  step_success_heading: "Connexion réussie",
+  step_error_heading: "Échec de la connexion",
+  search_label: "Rechercher des fournisseurs",
+  search_placeholder: "Rechercher des fournisseurs",
+  consent_bullets: [
+    "Ouvrir une session de navigation sécurisée avec le fournisseur choisi.",
+    "Chiffrer vos identifiants avant qu’ils ne quittent cette fenêtre.",
+    "Renvoyer une confirmation sécurisée à votre application une fois la vérification terminée.",
+  ],
+  success_message:
+    "Votre connexion sécurisée est établie. Retournez à votre application pour terminer la configuration.",
+  public_token_label: "JETON PUBLIC",
+  retry_cta: "Réessayer",
+  continue_cta: "Continuer",
+  verify_cta: "Vérifier et continuer",
+  live_select: "Choisissez votre fournisseur pour commencer.",
+  live_credentials: "Entrez vos identifiants pour le fournisseur sélectionné.",
+  live_connecting: "Connexion à votre fournisseur en cours.",
+  live_mfa: "Vérification supplémentaire requise.",
+  live_success: "Connexion réussie.",
+  live_error: "Échec de la connexion.",
+};
+
+export const MESSAGES: Readonly<Record<Locale, Messages>> = {
+  "en-US": EN_US,
+  "en-CA": EN_CA,
+  "fr-CA": FR_CA,
+};
+
+export function getMessages(locale: Locale | string | null | undefined): Messages {
+  if (locale && (locale as Locale) in MESSAGES) {
+    return MESSAGES[locale as Locale];
+  }
+  return MESSAGES[DEFAULT_LOCALE];
+}
+
+/**
+ * Parse an \`Accept-Language\` style header or \`navigator.languages\`
+ * array into the first supported locale. Matches on exact locale,
+ * then on language prefix (\`fr\` → \`fr-CA\`).
+ */
+function matchLocale(candidates: readonly string[]): Locale | null {
+  for (const raw of candidates) {
+    if (!raw) continue;
+    const tag = raw.trim();
+    const exact = SUPPORTED_LOCALES.find(
+      (l) => l.toLowerCase() === tag.toLowerCase(),
+    );
+    if (exact) return exact;
+    const prefix = tag.split("-")[0]?.toLowerCase();
+    if (!prefix) continue;
+    const byPrefix = SUPPORTED_LOCALES.find(
+      (l) => l.split("-")[0].toLowerCase() === prefix,
+    );
+    if (byPrefix) return byPrefix;
+  }
+  return null;
+}
+
+function parseAcceptLanguage(header: string): string[] {
+  return header
+    .split(",")
+    .map((entry) => {
+      const [tag, qPart] = entry.split(";");
+      const q = qPart
+        ? parseFloat(qPart.split("=")[1] ?? "1") || 0
+        : 1;
+      return { tag: (tag || "").trim(), q };
+    })
+    .filter((e) => e.tag.length > 0)
+    .sort((a, b) => b.q - a.q)
+    .map((e) => e.tag);
+}
+
+export interface LocaleResolutionInput {
+  readonly search?: string;
+  readonly acceptLanguage?: string;
+  readonly navigatorLanguages?: readonly string[];
+}
+
+export function resolveLocale(input: LocaleResolutionInput = {}): Locale {
+  if (input.search) {
+    const params = new URLSearchParams(input.search);
+    const explicit = params.get("locale");
+    if (explicit) {
+      const matched = matchLocale([explicit]);
+      if (matched) return matched;
+    }
+  }
+  if (input.acceptLanguage) {
+    const matched = matchLocale(parseAcceptLanguage(input.acceptLanguage));
+    if (matched) return matched;
+  }
+  if (input.navigatorLanguages && input.navigatorLanguages.length > 0) {
+    const matched = matchLocale(input.navigatorLanguages);
+    if (matched) return matched;
+  }
+  return DEFAULT_LOCALE;
+}
+
+export type Theme = "light" | "dark" | "system";
+
+export function resolveTheme(search?: string): Theme {
+  if (!search) return "system";
+  const params = new URLSearchParams(search);
+  const value = params.get("theme");
+  if (value === "light" || value === "dark") return value;
+  return "system";
+}
+
+/**
+ * Apply the requested theme to the document root. When \`system\`, we
+ * clear the override so the CSS \`@media (prefers-color-scheme)\`
+ * fallback kicks in.
+ */
+export function applyTheme(theme: Theme, root?: HTMLElement | null): void {
+  const target = root ?? (typeof document !== "undefined" ? document.documentElement : null);
+  if (!target) return;
+  if (theme === "system") {
+    target.removeAttribute("data-theme");
+  } else {
+    target.setAttribute("data-theme", theme);
+  }
+}

--- a/frontend-next/src/main.tsx
+++ b/frontend-next/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
 import { App } from "./App";
+import { applyTheme, resolveTheme } from "./i18n";
 import "./design/tokens.css";
 import "./design/primitives.css";
 import "./link.css";
@@ -10,6 +11,10 @@ const container = document.getElementById("root");
 if (!container) {
   throw new Error("Missing #root container for Plaidify hosted link app.");
 }
+
+// Apply the `?theme=light|dark` override (falls back to
+// `prefers-color-scheme` when absent).
+applyTheme(resolveTheme(window.location.search));
 
 createRoot(container).render(
   <StrictMode>


### PR DESCRIPTION
Closes #57.

## Summary
Adds locale negotiation and static message catalogs (`en-US`, `en-CA`, `fr-CA`) for the hosted /link UI, plus a `?theme=light|dark` override on top of the existing `prefers-color-scheme` dark-mode styles.

## Highlights
- **Locale negotiation**: `?locale=` → `Accept-Language` → `navigator.languages` → `en-US`.
- **Catalogs**: `frontend-next/src/i18n.ts` externalizes every user-facing string in `App.tsx` (headings, search label/placeholder, consent bullets, button labels, success/connecting copy, PUBLIC TOKEN label, live-region announcements, `fr-CA` fully translated).
- **E2E contract preserved**: `en-US`/`en-CA` keep the exact strings E2E + SSR tests rely on (`Return a secure completion back to your app…`, `Return to your app`, `PUBLIC TOKEN`).
- **`<main lang={locale}>`** surfaces the negotiated tag to assistive tech.
- **Theme**: `main.tsx` calls `applyTheme(resolveTheme(search))` so `?theme=dark` / `?theme=light` overrides the media-query fallback.

## Tests
- New `frontend-next/src/i18n.test.ts` (9 tests): catalog shape, E2E contract, resolveLocale priority order, prefix matching, resolveTheme, applyTheme DOM side-effects.
- Full frontend suite: 72/72 pass. Backend e2e smoke: 6/6 pass.