### PR TITLE
feat(link): skeleton loaders + choreographed step transitions (#60)

### DIFF
--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -36,6 +36,7 @@ import {
   getMessages,
   resolveLocale,
 } from "./i18n";
+import { SkeletonRowList } from "./Skeleton";
 import {
   flowReducer,
   initialFlowState,
@@ -548,6 +549,9 @@ export function App(props: AppProps = {}) {
             {searchError}
           </p>
         ) : null}
+        {organizations.length === 0 && !searchError ? (
+          <SkeletonRowList rows={4} />
+        ) : null}
         <ul id="institution-list" aria-label="Matching providers">
           {organizations.map((organization) => (
             <li
@@ -702,6 +706,7 @@ export function App(props: AppProps = {}) {
         >
           {messages.step_connecting_body}
         </p>
+        <SkeletonRowList rows={3} />
       </section>
 
       <section

--- a/frontend-next/src/Skeleton.test.tsx
+++ b/frontend-next/src/Skeleton.test.tsx
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { renderToString } from "react-dom/server";
+
+import { SkeletonRowList, SkeletonText } from "./Skeleton";
+
+describe("Skeleton primitives", () => {
+  it("SkeletonRowList renders the requested number of decorative rows", () => {
+    const html = renderToString(<SkeletonRowList rows={5} />);
+    const matches = html.match(/skeleton skeleton--row/g) ?? [];
+    expect(matches).toHaveLength(5);
+    expect(html).toContain('aria-hidden="true"');
+    expect(html).toContain('data-testid="skeleton-row-list"');
+  });
+
+  it("SkeletonRowList defaults to 4 rows", () => {
+    const html = renderToString(<SkeletonRowList />);
+    const matches = html.match(/skeleton skeleton--row/g) ?? [];
+    expect(matches).toHaveLength(4);
+  });
+
+  it("SkeletonText renders with the requested width", () => {
+    const html = renderToString(<SkeletonText widthPct={42} />);
+    expect(html).toContain("width:42%");
+    expect(html).toContain('aria-hidden="true"');
+  });
+});

--- a/frontend-next/src/Skeleton.tsx
+++ b/frontend-next/src/Skeleton.tsx
@@ -1,0 +1,41 @@
+/**
+ * Skeleton loader primitives for the hosted-link flow (issue #60).
+ *
+ * These are aria-hidden placeholders rendered while a network-bound
+ * state (directory search, MFA poll) is in flight. Real content
+ * replaces them as soon as the first response arrives — the live
+ * region announces step changes so screen-reader users aren't left
+ * parsing decorative skeletons.
+ *
+ * All shimmer animation is driven by CSS so the shared
+ * `prefers-reduced-motion` rule in link.css disables it automatically.
+ */
+import type { ReactElement } from "react";
+
+export interface SkeletonRowListProps {
+  readonly rows?: number;
+}
+
+export function SkeletonRowList({ rows = 4 }: SkeletonRowListProps): ReactElement {
+  return (
+    <ul className="skeleton-list" aria-hidden="true" data-testid="skeleton-row-list">
+      {Array.from({ length: rows }).map((_, i) => (
+        <li key={i} className="skeleton skeleton--row" />
+      ))}
+    </ul>
+  );
+}
+
+export function SkeletonText({
+  widthPct = 100,
+}: {
+  readonly widthPct?: number;
+}): ReactElement {
+  return (
+    <span
+      className="skeleton skeleton--text"
+      aria-hidden="true"
+      style={{ width: `${widthPct}%` }}
+    />
+  );
+}

--- a/frontend-next/src/link.css
+++ b/frontend-next/src/link.css
@@ -224,3 +224,67 @@
     scroll-behavior: auto !important;
   }
 }
+
+/* ── Motion polish (#60) ───────────────────────────────────────────── */
+@keyframes plaidify-skeleton-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+.skeleton {
+  display: block;
+  border-radius: var(--plaidify-radius-sm);
+  background: linear-gradient(
+    90deg,
+    var(--plaidify-color-bg-surface-alt) 0%,
+    var(--plaidify-color-bg-surface) 50%,
+    var(--plaidify-color-bg-surface-alt) 100%
+  );
+  background-size: 200% 100%;
+  animation: plaidify-skeleton-shimmer
+    var(--plaidify-duration-slow, 1200ms) linear infinite;
+}
+
+.skeleton--row {
+  height: 56px;
+  margin-bottom: var(--plaidify-space-2);
+}
+
+.skeleton--text {
+  height: 1em;
+  width: 100%;
+}
+
+.skeleton-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* Reserve space so the step transition never shifts layout. */
+.plaidify-link {
+  min-height: 420px;
+}
+
+/* Subtle fade-in for the active step. Duration is pulled from tokens
+ * so the existing reduced-motion rule near the top of this file zeros
+ * it out automatically. */
+.link-step.active {
+  animation: plaidify-step-fade-in var(--plaidify-duration-base, 220ms)
+    var(--plaidify-easing-standard, ease-out);
+}
+
+@keyframes plaidify-step-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}


### PR DESCRIPTION
Closes #60.

## Summary
Motion polish pass for hosted /link: skeleton loaders while network-bound states resolve, a subtle fade-in on step activation, and a reserved min-height so transitions don't shift layout. All new motion is gated by the existing `prefers-reduced-motion: reduce` rule.

## Changes
- New `Skeleton` primitives (`SkeletonRowList`, `SkeletonText`) — aria-hidden decorative placeholders.
- Picker renders a 4-row skeleton while organizations are loading.
- Connecting step renders a 3-row skeleton beneath the status line.
- CSS: `.skeleton` shimmer keyframes, `.link-step.active` fade-in keyframe, `.plaidify-link { min-height: 420px }`.
- All new animation obeys `prefers-reduced-motion: reduce` (already shipped in #56).

## Tests
- `Skeleton.test.tsx` covers default/custom row counts + SkeletonText width prop.
- Full frontend suite: 75/75 pass. Backend e2e: 3/3 pass.