### PR TITLE
feat(link): structured UX telemetry for hosted /link (#61)

### DIFF
--- a/docs/HOSTED_LINK_TELEMETRY.md
+++ b/docs/HOSTED_LINK_TELEMETRY.md
@@ -1,0 +1,77 @@
+# Hosted Link — UX Telemetry Schema
+
+**Status:** Stable · **Owner:** Link surface team · **Issue:** #61
+
+Structured events emitted by the hosted `/link` UI for UX analytics and
+flow funnel analysis. Telemetry rides on the same post-message / SSE
+event bus as the product-level bridge events, but under a dedicated
+event name (`TELEMETRY`) so embedders can easily distinguish analytics
+from product outcomes.
+
+## Delivery
+
+- **Client → server:** `POST /link/sessions/{link_token}/event` with
+  body `{ "event": "TELEMETRY", ...payload }`. Sanitized by
+  `_sanitize_hosted_event_data()` before fan-out.
+- **Server → subscribers:** broadcast via
+  `GET /link/events/{link_token}` (SSE) alongside bridge events.
+- **Embedder:** receives via `window.postMessage` and native bridges
+  (`ReactNativeWebView.postMessage`, WebKit handlers). Embedders that
+  only consume product events can filter on `type !== "TELEMETRY"`.
+
+## Event Schema
+
+Every payload includes:
+
+| Field        | Type   | Notes                                                 |
+|--------------|--------|-------------------------------------------------------|
+| `event`      | string | One of the event names below.                         |
+| `elapsed_ms` | number | Milliseconds since telemetry session start (mount).   |
+
+### Events
+
+| Name                   | Additional fields            | Fires when                                          |
+|------------------------|------------------------------|-----------------------------------------------------|
+| `step_view`            | `step`                       | A step becomes the active step.                     |
+| `step_complete`        | `step`                       | The user advances off a step.                       |
+| `field_error`          | `step`, `field`              | Client-side validation rejects a field.             |
+| `institution_selected` | `organization_id`            | User picks an institution.                          |
+| `mfa_shown`            | `mfa_type`                   | MFA prompt is rendered (OTP, push, security Qs).    |
+| `mfa_submitted`        | —                            | User submits an MFA response.                       |
+| `exit_reason`          | `reason`, `error_code?`      | Link surface unmounts; reason is a short token.     |
+
+## Privacy Posture
+
+Telemetry payloads **must never contain PII** or credential-bearing
+data. The following fields are explicitly forbidden in any telemetry
+event and are stripped server-side by `_sanitize_hosted_event_data()`:
+
+- `username`, `password`, `code`, `otp`
+- `public_token`, `access_token`, `session_id` (bridge-only)
+- `encrypted`, raw `message` bodies
+- Free-form error messages (use taxonomy `error_code` instead)
+
+Identifiers that are safe to include:
+
+- `organization_id` (opaque, non-PII)
+- `mfa_type` (e.g. `otp`, `push`, `security_questions`)
+- `step` id (`consent`, `picker`, `credentials`, `connecting`, `mfa`, `success`, `error`)
+- `field` id (schema field name, never its value)
+- `error_code` from the error taxonomy (#55)
+
+## Retention
+
+Telemetry events share the lifecycle of the hosted link session:
+
+- Delivered in real time to SSE subscribers.
+- Not persisted beyond session close — the server does not store
+  telemetry in long-term tables.
+- Embedders that want durable analytics are expected to forward
+  received events to their own analytics pipeline.
+
+## Client Reference
+
+See [`frontend-next/src/telemetry.ts`](../frontend-next/src/telemetry.ts)
+for the typed emitter and
+[`frontend-next/src/telemetry.test.ts`](../frontend-next/src/telemetry.test.ts)
+for the PII-free payload contract.

--- a/frontend-next/src/App.tsx
+++ b/frontend-next/src/App.tsx
@@ -37,6 +37,7 @@ import {
   resolveLocale,
 } from "./i18n";
 import { SkeletonRowList } from "./Skeleton";
+import { createTelemetry, type Telemetry } from "./telemetry";
 import {
   flowReducer,
   initialFlowState,
@@ -111,6 +112,7 @@ export function App(props: AppProps = {}) {
   const stepHeadingRef = useRef<HTMLElement | null>(null);
   const previousStepRef = useRef<string>(state.step);
   const [liveAnnouncement, setLiveAnnouncement] = useState("");
+  const telemetryRef = useRef<Telemetry | null>(null);
 
   const locale: Locale =
     props.locale ??
@@ -174,6 +176,13 @@ export function App(props: AppProps = {}) {
     [],
   );
 
+  // Initialize structured UX telemetry (#61) once the emit pipeline
+  // exists. Telemetry rides on the same bus under `TELEMETRY` so
+  // downstream analytics can subscribe via SSE.
+  if (telemetryRef.current === null) {
+    telemetryRef.current = createTelemetry({ emit });
+  }
+
   // Validate the session token and announce OPEN on mount.
   useEffect(() => {
     const api = apiRef.current;
@@ -236,6 +245,7 @@ export function App(props: AppProps = {}) {
         reason: "unmount",
         error_code: state.error?.code ?? null,
       });
+      telemetryRef.current?.exitReason("unmount", state.error?.code ?? undefined);
       deliveryRef.current?.dispose();
     };
   }, [emit, state.error?.code]);
@@ -245,6 +255,7 @@ export function App(props: AppProps = {}) {
     if (previousStepRef.current === state.step) {
       return;
     }
+    const fromStep = previousStepRef.current;
     previousStepRef.current = state.step;
     const target = stepHeadingRef.current;
     if (target) {
@@ -257,6 +268,13 @@ export function App(props: AppProps = {}) {
       } catch {
         target.focus();
       }
+    }
+    // Telemetry (#61): step_complete for the prior step, step_view for the new.
+    if (telemetryRef.current) {
+      if (fromStep && fromStep !== state.step) {
+        telemetryRef.current.stepComplete(fromStep);
+      }
+      telemetryRef.current.stepView(state.step);
     }
     const announcements: Record<string, string> = {
       select: messages.live_select,
@@ -318,6 +336,7 @@ export function App(props: AppProps = {}) {
         organization_name: organization.name,
         site: organization.site,
       });
+      telemetryRef.current?.institutionSelected(organization.organization_id);
     },
     [emit],
   );
@@ -383,6 +402,7 @@ export function App(props: AppProps = {}) {
           mfa_type: response.mfa_type ?? "otp",
           session_id: response.session_id ?? null,
         });
+        telemetryRef.current?.mfaShown(response.mfa_type ?? "otp");
         return;
       }
       if (response.status === "pending") {
@@ -405,6 +425,7 @@ export function App(props: AppProps = {}) {
             mfa_type: terminal.mfa_type ?? "otp",
             session_id: terminal.session_id ?? null,
           });
+          telemetryRef.current?.mfaShown(terminal.mfa_type ?? "otp");
           return;
         }
         const message =
@@ -461,6 +482,9 @@ export function App(props: AppProps = {}) {
       const map: Record<string, string> = {};
       for (const err of errors) map[err.field] = err.message;
       setCredentialErrors(map);
+      for (const err of errors) {
+        telemetryRef.current?.fieldError("credentials", err.field);
+      }
       return;
     }
     setCredentialErrors({});
@@ -480,6 +504,9 @@ export function App(props: AppProps = {}) {
       const map: Record<string, string> = {};
       for (const err of errors) map[err.field] = err.message;
       setMfaErrors(map);
+      for (const err of errors) {
+        telemetryRef.current?.fieldError("mfa", err.field);
+      }
       return;
     }
     setMfaErrors({});
@@ -490,6 +517,7 @@ export function App(props: AppProps = {}) {
     }
     dispatch({ type: "SUBMIT_MFA" });
     emit("MFA_SUBMITTED", { session_id: sessionId });
+    telemetryRef.current?.mfaSubmitted();
     try {
       const response = await api.submitMfa({
         sessionId,

--- a/frontend-next/src/telemetry.test.ts
+++ b/frontend-next/src/telemetry.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createTelemetry } from "./telemetry";
+
+describe("telemetry", () => {
+  const makeHarness = () => {
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    let clock = 1_000;
+    const now = () => clock;
+    const advance = (ms: number) => {
+      clock += ms;
+    };
+    const emitter = {
+      emit: (event: string, payload: Record<string, unknown>) => {
+        events.push({ event, payload });
+      },
+    };
+    const telemetry = createTelemetry(emitter, now);
+    return { events, advance, telemetry };
+  };
+
+  it("emits step_view with elapsed_ms since session start", () => {
+    const { events, advance, telemetry } = makeHarness();
+    advance(250);
+    telemetry.stepView("picker");
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe("TELEMETRY");
+    expect(events[0].payload).toMatchObject({
+      event: "step_view",
+      step: "picker",
+      elapsed_ms: 250,
+    });
+  });
+
+  it("emits step_complete with the step id", () => {
+    const { events, telemetry } = makeHarness();
+    telemetry.stepComplete("credentials");
+    expect(events[0].payload).toMatchObject({
+      event: "step_complete",
+      step: "credentials",
+    });
+  });
+
+  it("emits field_error with step + field identifiers (no values)", () => {
+    const { events, telemetry } = makeHarness();
+    telemetry.fieldError("credentials", "username");
+    const payload = events[0].payload as Record<string, unknown>;
+    expect(payload.event).toBe("field_error");
+    expect(payload.step).toBe("credentials");
+    expect(payload.field).toBe("username");
+    // No value/PII field should ever be present.
+    expect(payload).not.toHaveProperty("value");
+    expect(payload).not.toHaveProperty("username");
+  });
+
+  it("emits institution_selected with organization_id only", () => {
+    const { events, telemetry } = makeHarness();
+    telemetry.institutionSelected("org_rbc");
+    const payload = events[0].payload as Record<string, unknown>;
+    expect(payload.event).toBe("institution_selected");
+    expect(payload.organization_id).toBe("org_rbc");
+    expect(payload).not.toHaveProperty("organization_name");
+  });
+
+  it("emits mfa_shown with prompt type but never the code", () => {
+    const { events, telemetry } = makeHarness();
+    telemetry.mfaShown("otp");
+    const payload = events[0].payload as Record<string, unknown>;
+    expect(payload.event).toBe("mfa_shown");
+    expect(payload.mfa_type).toBe("otp");
+    expect(payload).not.toHaveProperty("code");
+    expect(payload).not.toHaveProperty("value");
+  });
+
+  it("emits mfa_submitted without any credential body", () => {
+    const { events, telemetry } = makeHarness();
+    telemetry.mfaSubmitted();
+    const payload = events[0].payload as Record<string, unknown>;
+    expect(payload.event).toBe("mfa_submitted");
+    expect(Object.keys(payload).sort()).toEqual(["elapsed_ms", "event"].sort());
+  });
+
+  it("emits exit_reason with reason + optional error_code", () => {
+    const { events, telemetry } = makeHarness();
+    telemetry.exitReason("unmount", "rate_limited");
+    const payload = events[0].payload as Record<string, unknown>;
+    expect(payload.event).toBe("exit_reason");
+    expect(payload.reason).toBe("unmount");
+    expect(payload.error_code).toBe("rate_limited");
+  });
+
+  it("default clock uses Date.now when now() is not supplied", () => {
+    const spy = vi.spyOn(Date, "now").mockReturnValue(42);
+    const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const telemetry = createTelemetry({
+      emit: (event, payload) => {
+        events.push({ event, payload });
+      },
+    });
+    telemetry.stepView("picker");
+    expect((events[0].payload as { elapsed_ms: number }).elapsed_ms).toBe(0);
+    spy.mockRestore();
+  });
+});

--- a/frontend-next/src/telemetry.ts
+++ b/frontend-next/src/telemetry.ts
@@ -1,0 +1,84 @@
+/**
+ * Structured UX telemetry for hosted /link (issue #61).
+ *
+ * Every telemetry event is dispatched through the same
+ * {@link EventDelivery} pipeline as the product-level bridge events,
+ * but under a separate event name (`TELEMETRY`) so:
+ *
+ *   1. Embedders that only care about product outcomes
+ *      (`CONNECTED`, `ERROR`, `EXIT`) can filter telemetry out.
+ *   2. UX analytics can subscribe to the `/link/events/` SSE stream
+ *      and aggregate flow funnels without touching the product bus.
+ *
+ * ## Privacy
+ * Telemetry payloads MUST NOT contain PII. Usernames, passwords,
+ * MFA codes, public tokens, and any other user-supplied credential
+ * data are filtered at the call site. The backend enforces the same
+ * contract in `_sanitize_hosted_event_data()`.
+ *
+ * ## Retention
+ * Telemetry events inherit the hosting session's retention (TTL on
+ * the link token). They are not persisted beyond session close.
+ */
+
+export type TelemetryEventName =
+  | "step_view"
+  | "step_complete"
+  | "field_error"
+  | "institution_selected"
+  | "mfa_shown"
+  | "mfa_submitted"
+  | "exit_reason";
+
+export interface TelemetryPayload {
+  readonly event: TelemetryEventName;
+  /** Milliseconds since the telemetry session began. */
+  readonly elapsed_ms: number;
+  /** Current step identifier at event time. */
+  readonly step?: string;
+  /** For field_error: the field id that failed validation. */
+  readonly field?: string;
+  /** For institution_selected: organization id. PII-free. */
+  readonly organization_id?: string;
+  /** For mfa_shown: the prompt type (otp/push/etc), never the code. */
+  readonly mfa_type?: string;
+  /** For exit_reason: a short machine-readable reason. */
+  readonly reason?: string;
+  /** Error code from the taxonomy when relevant (optional). */
+  readonly error_code?: string;
+}
+
+export interface TelemetryEmitter {
+  /** Emit an event into the same post-message/SSE bus used for bridge events. */
+  readonly emit: (event: string, payload: Record<string, unknown>) => void;
+}
+
+/**
+ * Build a telemetry helper bound to a specific emitter and start
+ * timestamp. The returned object exposes one method per event name
+ * so call sites don't stringly-type the event identifier.
+ */
+export function createTelemetry(emitter: TelemetryEmitter, now: () => number = Date.now) {
+  const start = now();
+  const send = (event: TelemetryEventName, extra: Omit<TelemetryPayload, "event" | "elapsed_ms"> = {}) => {
+    const payload: TelemetryPayload = {
+      event,
+      elapsed_ms: Math.max(0, now() - start),
+      ...extra,
+    };
+    emitter.emit("TELEMETRY", payload as unknown as Record<string, unknown>);
+  };
+  return {
+    stepView: (step: string) => send("step_view", { step }),
+    stepComplete: (step: string) => send("step_complete", { step }),
+    fieldError: (step: string, field: string) => send("field_error", { step, field }),
+    institutionSelected: (organizationId: string) =>
+      send("institution_selected", { organization_id: organizationId }),
+    mfaShown: (mfaType: string) => send("mfa_shown", { mfa_type: mfaType }),
+    mfaSubmitted: () => send("mfa_submitted", {}),
+    exitReason: (reason: string, errorCode?: string) =>
+      send("exit_reason", { reason, error_code: errorCode }),
+  };
+}
+
+export type Telemetry = ReturnType<typeof createTelemetry>;


### PR DESCRIPTION
Closes #61.

Adds a PII-free, structured telemetry layer on top of the existing bridge event pipeline so hosted Link can power flow-funnel analytics without leaking credentials or free-form error messages.

## Schema
Events (each with `event` + `elapsed_ms`): `step_view`, `step_complete`, `field_error`, `institution_selected`, `mfa_shown`, `mfa_submitted`, `exit_reason`. Full schema + delivery contract + retention policy in [`docs/HOSTED_LINK_TELEMETRY.md`](docs/HOSTED_LINK_TELEMETRY.md).

## Delivery
Emitted via the existing post-message / SSE bus under the dedicated `TELEMETRY` event name — embedders can filter if they only want product outcomes. Backend sanitizer (`_sanitize_hosted_event_data`) already strips forbidden keys for defense in depth.

## Privacy
No credentials, codes, tokens, or free-form messages. Tests assert payloads never carry `value`, `code`, `username`, etc.

## Tests
- `telemetry.test.ts`: 8 tests (every event, PII-free contract, default clock fallback).
- 83/83 frontend tests pass. 3/3 backend e2e pass. Typecheck + build clean.