### PR TITLE
feat(sdk-swift): native SwiftUI Link screens with WKWebView fallback (#58)

### DIFF
--- a/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkClient.swift
+++ b/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkClient.swift
@@ -1,0 +1,286 @@
+import Foundation
+
+/// Errors emitted by ``PlaidifyLinkClient``.
+public enum PlaidifyLinkClientError: Error, Equatable {
+    case invalidURL
+    case transport(String)
+    case http(status: Int, errorCode: String?, message: String)
+    case decoding(String)
+}
+
+/// Status payload returned by `GET /link/sessions/{token}/status`.
+public struct PlaidifyLinkSessionStatus: Codable, Equatable {
+    public let status: String
+    public let site: String?
+    public let mfaType: String?
+    public let sessionID: String?
+    public let publicToken: String?
+    public let errorMessage: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case status
+        case site
+        case mfaType = "mfa_type"
+        case sessionID = "session_id"
+        case publicToken = "public_token"
+        case errorMessage = "error_message"
+    }
+}
+
+/// Organization record returned by `/organizations/search`.
+public struct PlaidifyOrganization: Codable, Equatable, Identifiable {
+    public let organizationID: String
+    public let name: String
+    public let site: String
+    public let logoURL: String?
+    public let primaryColor: String?
+    public let accentColor: String?
+    public let secondaryColor: String?
+    public let hintCopy: String?
+    public let authStyle: String?
+
+    public var id: String { organizationID }
+
+    public enum CodingKeys: String, CodingKey {
+        case organizationID = "organization_id"
+        case name
+        case site
+        case logoURL = "logo_url"
+        case primaryColor = "primary_color"
+        case accentColor = "accent_color"
+        case secondaryColor = "secondary_color"
+        case hintCopy = "hint_copy"
+        case authStyle = "auth_style"
+    }
+}
+
+public struct PlaidifyOrganizationSearchResponse: Codable, Equatable {
+    public let organizations: [PlaidifyOrganization]
+}
+
+/// Encrypted credential pair posted to `/connect`.
+public struct PlaidifyEncryptedCredentials: Equatable {
+    public let username: String
+    public let password: String
+
+    public init(username: String, password: String) {
+        self.username = username
+        self.password = password
+    }
+}
+
+/// Response payload from `/connect` and `/mfa/submit`.
+public struct PlaidifyConnectResponse: Codable, Equatable {
+    public let status: String
+    public let sessionID: String?
+    public let mfaType: String?
+    public let publicToken: String?
+    public let jobID: String?
+    public let message: String?
+    public let errorMessage: String?
+
+    public enum CodingKeys: String, CodingKey {
+        case status
+        case sessionID = "session_id"
+        case mfaType = "mfa_type"
+        case publicToken = "public_token"
+        case jobID = "job_id"
+        case message
+        case errorMessage = "error_message"
+    }
+}
+
+/// Minimal abstraction over `URLSession` so the client is testable.
+public protocol PlaidifyLinkHTTPClient {
+    func data(for request: URLRequest) async throws -> (Data, URLResponse)
+}
+
+extension URLSession: PlaidifyLinkHTTPClient {}
+
+/// Builds canonical URLs for Plaidify Link REST endpoints.
+///
+/// Extracted from the client so it can be unit-tested without
+/// performing network I/O.
+public enum PlaidifyLinkURLBuilder {
+    public static func base(_ serverURL: URL) -> String {
+        let absolute = serverURL.absoluteString
+        return absolute.hasSuffix("/") ? String(absolute.dropLast()) : absolute
+    }
+
+    public static func status(serverURL: URL, linkToken: String) -> URL? {
+        let escaped = linkToken.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? linkToken
+        return URL(string: base(serverURL) + "/link/sessions/\(escaped)/status")
+    }
+
+    public static func organizationSearch(
+        serverURL: URL,
+        query: String?,
+        site: String?,
+        limit: Int
+    ) -> URL? {
+        var components = URLComponents(string: base(serverURL) + "/organizations/search")
+        var items: [URLQueryItem] = [URLQueryItem(name: "limit", value: String(limit))]
+        if let query, !query.isEmpty {
+            items.append(URLQueryItem(name: "q", value: query))
+        }
+        if let site, !site.isEmpty {
+            items.append(URLQueryItem(name: "site", value: site))
+        }
+        components?.queryItems = items
+        return components?.url
+    }
+
+    public static func encryptionPublicKey(serverURL: URL, linkToken: String) -> URL? {
+        let escaped = linkToken.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? linkToken
+        return URL(string: base(serverURL) + "/encryption/public_key/\(escaped)")
+    }
+
+    public static func connect(serverURL: URL) -> URL? {
+        URL(string: base(serverURL) + "/connect")
+    }
+
+    public static func mfaSubmit(serverURL: URL, sessionID: String, code: String) -> URL? {
+        var components = URLComponents(string: base(serverURL) + "/mfa/submit")
+        components?.queryItems = [
+            URLQueryItem(name: "session_id", value: sessionID),
+            URLQueryItem(name: "code", value: code),
+        ]
+        return components?.url
+    }
+}
+
+/// REST client that talks to the same hosted-link endpoints as the
+/// React frontend. All methods are `async throws`.
+public final class PlaidifyLinkClient {
+    public let serverURL: URL
+    public let linkToken: String
+
+    private let http: PlaidifyLinkHTTPClient
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    public init(
+        serverURL: URL,
+        linkToken: String,
+        http: PlaidifyLinkHTTPClient = URLSession.shared
+    ) {
+        self.serverURL = serverURL
+        self.linkToken = linkToken
+        self.http = http
+        self.decoder = JSONDecoder()
+        self.encoder = JSONEncoder()
+    }
+
+    public func getStatus() async throws -> PlaidifyLinkSessionStatus {
+        guard let url = PlaidifyLinkURLBuilder.status(serverURL: serverURL, linkToken: linkToken) else {
+            throw PlaidifyLinkClientError.invalidURL
+        }
+        return try await send(URLRequest(url: url))
+    }
+
+    public func searchOrganizations(
+        query: String? = nil,
+        site: String? = nil,
+        limit: Int = 40
+    ) async throws -> PlaidifyOrganizationSearchResponse {
+        guard let url = PlaidifyLinkURLBuilder.organizationSearch(
+            serverURL: serverURL,
+            query: query,
+            site: site,
+            limit: limit
+        ) else {
+            throw PlaidifyLinkClientError.invalidURL
+        }
+        return try await send(URLRequest(url: url))
+    }
+
+    public func getEncryptionPublicKey() async throws -> [String: String] {
+        guard let url = PlaidifyLinkURLBuilder.encryptionPublicKey(
+            serverURL: serverURL,
+            linkToken: linkToken
+        ) else {
+            throw PlaidifyLinkClientError.invalidURL
+        }
+        return try await send(URLRequest(url: url))
+    }
+
+    public func connect(
+        site: String,
+        encrypted: PlaidifyEncryptedCredentials
+    ) async throws -> PlaidifyConnectResponse {
+        guard let url = PlaidifyLinkURLBuilder.connect(serverURL: serverURL) else {
+            throw PlaidifyLinkClientError.invalidURL
+        }
+        let body: [String: String] = [
+            "link_token": linkToken,
+            "site": site,
+            "encrypted_username": encrypted.username,
+            "encrypted_password": encrypted.password,
+        ]
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try encoder.encode(body)
+        return try await send(request)
+    }
+
+    public func submitMFA(sessionID: String, code: String) async throws -> PlaidifyConnectResponse {
+        guard let url = PlaidifyLinkURLBuilder.mfaSubmit(
+            serverURL: serverURL,
+            sessionID: sessionID,
+            code: code
+        ) else {
+            throw PlaidifyLinkClientError.invalidURL
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        return try await send(request)
+    }
+
+    // MARK: - Internals
+
+    private func send<T: Decodable>(_ request: URLRequest) async throws -> T {
+        var req = request
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await http.data(for: req)
+        } catch {
+            throw PlaidifyLinkClientError.transport(error.localizedDescription)
+        }
+        let status = (response as? HTTPURLResponse)?.statusCode ?? 0
+        if !(200..<300).contains(status) {
+            let info = try? decoder.decode(PlaidifyLinkErrorBody.self, from: data)
+            throw PlaidifyLinkClientError.http(
+                status: status,
+                errorCode: info?.errorCode,
+                message: info?.detail ?? info?.error ?? "HTTP \(status)"
+            )
+        }
+        if T.self == EmptyResponse.self {
+            // Should never be requested via this typed path, but keep for clarity.
+            return EmptyResponse() as! T
+        }
+        do {
+            return try decoder.decode(T.self, from: data)
+        } catch {
+            throw PlaidifyLinkClientError.decoding(error.localizedDescription)
+        }
+    }
+}
+
+private struct PlaidifyLinkErrorBody: Decodable {
+    let detail: String?
+    let error: String?
+    let errorCode: String?
+
+    enum CodingKeys: String, CodingKey {
+        case detail
+        case error
+        case errorCode = "error_code"
+    }
+}
+
+/// Marker type so the generic `send` path can be used for the rare
+/// no-body endpoint without making the function non-generic.
+public struct EmptyResponse: Decodable {}

--- a/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkConnectFlow.swift
+++ b/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkConnectFlow.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Step a hosted-link flow is currently on. Mirrors the React app's
+/// reducer so embedders see a consistent state machine.
+public enum PlaidifyLinkStep: String, Equatable {
+    case consent
+    case picker
+    case credentials
+    case connecting
+    case mfa
+    case success
+    case error
+}
+
+/// A single observed callback emitted by the flow. Callers translate
+/// these into native UI updates and/or webview bridge events.
+public enum PlaidifyLinkFlowEvent: Equatable {
+    case stepChanged(PlaidifyLinkStep)
+    case institutionSelected(PlaidifyOrganization)
+    case mfaRequired(type: String, sessionID: String?)
+    case connected(publicToken: String?, jobID: String?, site: String?)
+    case errored(code: String?, message: String)
+    case fallbackToWebView(PlaidifyOrganization, reason: String)
+}
+
+/// Pure state for the connect flow. Holds no UI dependencies so it
+/// can be unit-tested under `swift test` without simulator/device.
+public struct PlaidifyLinkFlowState: Equatable {
+    public var step: PlaidifyLinkStep
+    public var organization: PlaidifyOrganization?
+    public var sessionID: String?
+    public var mfaType: String?
+    public var lastErrorCode: String?
+    public var lastErrorMessage: String?
+    public var publicToken: String?
+    public var jobID: String?
+
+    public init(
+        step: PlaidifyLinkStep = .picker,
+        organization: PlaidifyOrganization? = nil,
+        sessionID: String? = nil,
+        mfaType: String? = nil,
+        lastErrorCode: String? = nil,
+        lastErrorMessage: String? = nil,
+        publicToken: String? = nil,
+        jobID: String? = nil
+    ) {
+        self.step = step
+        self.organization = organization
+        self.sessionID = sessionID
+        self.mfaType = mfaType
+        self.lastErrorCode = lastErrorCode
+        self.lastErrorMessage = lastErrorMessage
+        self.publicToken = publicToken
+        self.jobID = jobID
+    }
+}
+
+/// Coordinates the picker → credentials → MFA → success transitions.
+///
+/// The flow is driven by `apply` calls so a UI layer (SwiftUI/UIKit)
+/// can dispatch user actions and observe the resulting events without
+/// owning any business logic.
+public final class PlaidifyLinkConnectFlow {
+    public private(set) var state: PlaidifyLinkFlowState
+    public let registry: PlaidifyLinkInstitutionRegistry
+    public var onEvent: (PlaidifyLinkFlowEvent) -> Void
+
+    public init(
+        registry: PlaidifyLinkInstitutionRegistry = PlaidifyLinkInstitutionRegistry(),
+        initialState: PlaidifyLinkFlowState = PlaidifyLinkFlowState(),
+        onEvent: @escaping (PlaidifyLinkFlowEvent) -> Void = { _ in }
+    ) {
+        self.registry = registry
+        self.state = initialState
+        self.onEvent = onEvent
+    }
+
+    public enum Action: Equatable {
+        case selectInstitution(PlaidifyOrganization)
+        case credentialsSubmitted
+        case connectResponded(PlaidifyConnectResponse)
+        case mfaSubmitted
+        case mfaResponded(PlaidifyConnectResponse)
+        case failed(code: String?, message: String)
+        case reset
+    }
+
+    @discardableResult
+    public func apply(_ action: Action) -> PlaidifyLinkFlowState {
+        switch action {
+        case .selectInstitution(let organization):
+            switch registry.strategy(for: organization) {
+            case .webViewFallback(let reason):
+                onEvent(.fallbackToWebView(organization, reason: reason))
+                state.organization = organization
+            case .native:
+                state.organization = organization
+                state.step = .credentials
+                onEvent(.institutionSelected(organization))
+                onEvent(.stepChanged(.credentials))
+            }
+
+        case .credentialsSubmitted:
+            state.step = .connecting
+            onEvent(.stepChanged(.connecting))
+
+        case .connectResponded(let response):
+            handleConnectResponse(response)
+
+        case .mfaSubmitted:
+            state.step = .connecting
+            onEvent(.stepChanged(.connecting))
+
+        case .mfaResponded(let response):
+            handleConnectResponse(response)
+
+        case .failed(let code, let message):
+            state.step = .error
+            state.lastErrorCode = code
+            state.lastErrorMessage = message
+            onEvent(.errored(code: code, message: message))
+            onEvent(.stepChanged(.error))
+
+        case .reset:
+            state = PlaidifyLinkFlowState()
+            onEvent(.stepChanged(.picker))
+        }
+        return state
+    }
+
+    private func handleConnectResponse(_ response: PlaidifyConnectResponse) {
+        switch response.status {
+        case "completed":
+            state.step = .success
+            state.publicToken = response.publicToken
+            state.jobID = response.jobID
+            onEvent(.connected(
+                publicToken: response.publicToken,
+                jobID: response.jobID,
+                site: state.organization?.site
+            ))
+            onEvent(.stepChanged(.success))
+
+        case "mfa_required":
+            state.step = .mfa
+            state.sessionID = response.sessionID
+            state.mfaType = response.mfaType
+            onEvent(.mfaRequired(type: response.mfaType ?? "otp", sessionID: response.sessionID))
+            onEvent(.stepChanged(.mfa))
+
+        case "error":
+            apply(.failed(code: nil, message: response.errorMessage ?? response.message ?? "Connection failed."))
+
+        default:
+            // pending / unknown: stay on connecting
+            break
+        }
+    }
+}

--- a/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkInstitutionRegistry.swift
+++ b/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkInstitutionRegistry.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Decision returned by the registry when the SDK asks "can I render
+/// the native flow for this institution?"
+public enum PlaidifyLinkInstitutionStrategy: Equatable {
+    /// The native picker / credentials / MFA screens should be used.
+    case native
+    /// The institution requires the WKWebView hosted-link fallback.
+    case webViewFallback(reason: String)
+}
+
+/// Registry of institutions covered by the native UI. Long-tail
+/// institutions fall back to the WKWebView so they continue to work
+/// without a UI release.
+public struct PlaidifyLinkInstitutionRegistry: Equatable {
+    public let supportedSites: Set<String>
+    public let supportedAuthStyles: Set<String>
+
+    public init(
+        supportedSites: Set<String> = PlaidifyLinkInstitutionRegistry.defaultSupportedSites,
+        supportedAuthStyles: Set<String> = PlaidifyLinkInstitutionRegistry.defaultSupportedAuthStyles
+    ) {
+        self.supportedSites = supportedSites
+        self.supportedAuthStyles = supportedAuthStyles
+    }
+
+    /// Default coverage. Conservative: only username/password style
+    /// institutions are eligible for native rendering today; everything
+    /// else (OAuth redirects, security questions, push) falls through.
+    public static let defaultSupportedAuthStyles: Set<String> = [
+        "username_password",
+        "username_password_otp",
+    ]
+
+    /// Out-of-the-box, the native flow covers no specific sites; embedders
+    /// may opt institutions in by passing a custom registry. This keeps
+    /// a release-safe default of webview for everything until each
+    /// connector is explicitly verified.
+    public static let defaultSupportedSites: Set<String> = []
+
+    /// Decide whether ``organization`` can be rendered natively.
+    public func strategy(for organization: PlaidifyOrganization) -> PlaidifyLinkInstitutionStrategy {
+        if !supportedSites.isEmpty && !supportedSites.contains(organization.site) {
+            return .webViewFallback(reason: "site_not_in_native_registry")
+        }
+        if let style = organization.authStyle, !supportedAuthStyles.contains(style) {
+            return .webViewFallback(reason: "auth_style_unsupported:\(style)")
+        }
+        if organization.authStyle == nil && supportedSites.isEmpty {
+            // Empty registry + unknown auth style → webview is the safer choice.
+            return .webViewFallback(reason: "auth_style_unknown")
+        }
+        return .native
+    }
+}

--- a/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkScreens.swift
+++ b/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkScreens.swift
@@ -1,0 +1,192 @@
+#if canImport(SwiftUI)
+import Foundation
+import SwiftUI
+
+/// SwiftUI screens that render the Plaidify hosted Link flow natively.
+///
+/// These views are intentionally lightweight: they own no business
+/// logic, deferring all decisions to ``PlaidifyLinkConnectFlow`` and
+/// ``PlaidifyLinkClient``. Embedders that want a different look-and-feel
+/// can replace the views entirely while keeping the flow + client.
+@available(iOS 15.0, macOS 13.0, *)
+public struct PlaidifyLinkPickerView: View {
+    public let organizations: [PlaidifyOrganization]
+    public let onSelect: (PlaidifyOrganization) -> Void
+    @State private var query: String = ""
+
+    public init(
+        organizations: [PlaidifyOrganization],
+        onSelect: @escaping (PlaidifyOrganization) -> Void
+    ) {
+        self.organizations = organizations
+        self.onSelect = onSelect
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Select your bank")
+                .font(.title2.bold())
+                .accessibilityAddTraits(.isHeader)
+            TextField("Search institutions", text: $query)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("Search institutions")
+            List(filtered) { organization in
+                Button {
+                    onSelect(organization)
+                } label: {
+                    HStack(spacing: 12) {
+                        Text(organization.name)
+                            .font(.body)
+                        Spacer()
+                        Text(organization.site)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .accessibilityLabel("Select \(organization.name)")
+            }
+        }
+        .padding()
+    }
+
+    private var filtered: [PlaidifyOrganization] {
+        let trimmed = query.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return organizations }
+        return organizations.filter { org in
+            org.name.range(of: trimmed, options: .caseInsensitive) != nil
+                || org.site.range(of: trimmed, options: .caseInsensitive) != nil
+        }
+    }
+}
+
+@available(iOS 15.0, macOS 13.0, *)
+public struct PlaidifyLinkCredentialsView: View {
+    public let organization: PlaidifyOrganization
+    public let onSubmit: (String, String) -> Void
+    @State private var username: String = ""
+    @State private var password: String = ""
+
+    public init(
+        organization: PlaidifyOrganization,
+        onSubmit: @escaping (String, String) -> Void
+    ) {
+        self.organization = organization
+        self.onSubmit = onSubmit
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Sign in to \(organization.name)")
+                .font(.title2.bold())
+                .accessibilityAddTraits(.isHeader)
+            if let hint = organization.hintCopy {
+                Text(hint)
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+            }
+            TextField("Username", text: $username)
+                .textFieldStyle(.roundedBorder)
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                .keyboardType(.emailAddress)
+                #endif
+                .accessibilityLabel("Username")
+            SecureField("Password", text: $password)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("Password")
+            Button {
+                onSubmit(username, password)
+            } label: {
+                Text("Continue")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(username.isEmpty || password.isEmpty)
+            .accessibilityLabel("Continue to verify credentials")
+        }
+        .padding()
+    }
+}
+
+@available(iOS 15.0, macOS 13.0, *)
+public struct PlaidifyLinkMFAView: View {
+    public let prompt: String
+    public let onSubmit: (String) -> Void
+    @State private var code: String = ""
+
+    public init(prompt: String, onSubmit: @escaping (String) -> Void) {
+        self.prompt = prompt
+        self.onSubmit = onSubmit
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Verify your identity")
+                .font(.title2.bold())
+                .accessibilityAddTraits(.isHeader)
+            Text(prompt)
+                .font(.callout)
+                .foregroundColor(.secondary)
+            TextField("Verification code", text: $code)
+                .textFieldStyle(.roundedBorder)
+                #if os(iOS)
+                .keyboardType(.numberPad)
+                #endif
+                .accessibilityLabel("Verification code")
+            Button {
+                onSubmit(code)
+            } label: {
+                Text("Submit")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(code.isEmpty)
+            .accessibilityLabel("Submit verification code")
+        }
+        .padding()
+    }
+}
+
+@available(iOS 15.0, macOS 13.0, *)
+public struct PlaidifyLinkProgressView: View {
+    public let title: String
+    public init(title: String) {
+        self.title = title
+    }
+    public var body: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .accessibilityLabel(title)
+            Text(title)
+                .font(.body)
+        }
+        .padding()
+    }
+}
+
+@available(iOS 15.0, macOS 13.0, *)
+public struct PlaidifyLinkErrorView: View {
+    public let message: String
+    public let onRetry: () -> Void
+    public init(message: String, onRetry: @escaping () -> Void) {
+        self.message = message
+        self.onRetry = onRetry
+    }
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Something went wrong")
+                .font(.title2.bold())
+                .accessibilityAddTraits(.isHeader)
+            Text(message)
+                .font(.callout)
+                .foregroundColor(.secondary)
+            Button("Try again", action: onRetry)
+                .buttonStyle(.borderedProminent)
+                .accessibilityLabel("Retry connection")
+        }
+        .padding()
+    }
+}
+#endif

--- a/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkViewController.swift
+++ b/sdk-swift/Sources/PlaidifyLinkKit/PlaidifyLinkViewController.swift
@@ -1,0 +1,260 @@
+#if canImport(UIKit) && !os(macOS) && !os(watchOS) && !os(tvOS)
+import Foundation
+import SwiftUI
+import UIKit
+import WebKit
+
+/// UIKit entrypoint that hosts the native Plaidify Link flow and falls
+/// back to the existing WKWebView surface when an institution isn't
+/// covered by the native UI yet.
+///
+/// Embedders integrate via:
+///
+/// ```swift
+/// let vc = PlaidifyLinkViewController(
+///     hostedConfiguration: config,
+///     onEvent: { event in ... }
+/// )
+/// present(vc, animated: true)
+/// ```
+@available(iOS 15.0, *)
+public final class PlaidifyLinkViewController: UIViewController {
+    public typealias EventHandler = (PlaidifyLinkEvent) -> Void
+
+    public let hostedConfiguration: PlaidifyHostedLinkConfiguration
+    public let registry: PlaidifyLinkInstitutionRegistry
+    public let onEvent: EventHandler
+
+    private var hostingController: UIHostingController<AnyView>?
+    private var webView: WKWebView?
+    private var messageHandler: PlaidifyLinkScriptMessageHandler?
+    private let client: PlaidifyLinkClient
+    private let flow: PlaidifyLinkConnectFlow
+
+    public init(
+        hostedConfiguration: PlaidifyHostedLinkConfiguration,
+        registry: PlaidifyLinkInstitutionRegistry = PlaidifyLinkInstitutionRegistry(),
+        onEvent: @escaping EventHandler
+    ) {
+        self.hostedConfiguration = hostedConfiguration
+        self.registry = registry
+        self.onEvent = onEvent
+        self.client = PlaidifyLinkClient(
+            serverURL: hostedConfiguration.serverURL,
+            linkToken: hostedConfiguration.token
+        )
+        self.flow = PlaidifyLinkConnectFlow(registry: registry)
+        super.init(nibName: nil, bundle: nil)
+
+        flow.onEvent = { [weak self] event in
+            self?.translate(event)
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        showPicker()
+    }
+
+    // MARK: - Presentation
+
+    private func showPicker() {
+        let placeholder = AnyView(
+            PlaidifyLinkProgressView(title: "Loading institutions…")
+        )
+        replaceContent(with: placeholder)
+        Task { [weak self] in
+            guard let self else { return }
+            do {
+                let response = try await self.client.searchOrganizations(query: nil, limit: 40)
+                await MainActor.run {
+                    self.replaceContent(with: AnyView(
+                        PlaidifyLinkPickerView(organizations: response.organizations) { org in
+                            self.flow.apply(.selectInstitution(org))
+                        }
+                    ))
+                }
+            } catch {
+                await MainActor.run {
+                    self.flow.apply(.failed(code: nil, message: "\(error)"))
+                }
+            }
+        }
+    }
+
+    private func showCredentials(for organization: PlaidifyOrganization) {
+        replaceContent(with: AnyView(
+            PlaidifyLinkCredentialsView(organization: organization) { [weak self] _, _ in
+                // Encryption + connect happen at the app integration layer
+                // (the SDK does not bundle WebCrypto-equivalent code).
+                // We expose `CREDENTIALS_SUBMITTED` and let the host app
+                // post-process and call back into the flow with the
+                // connect response.
+                self?.onEvent(PlaidifyLinkEvent(
+                    source: "plaidify-link",
+                    event: PlaidifyLinkEventName.credentialsSubmitted.rawValue,
+                    jobID: nil,
+                    publicToken: nil,
+                    organizationID: organization.organizationID,
+                    organizationName: organization.name,
+                    site: organization.site,
+                    mfaType: nil,
+                    sessionID: nil,
+                    error: nil,
+                    reason: nil
+                ))
+                self?.flow.apply(.credentialsSubmitted)
+            }
+        ))
+    }
+
+    private func showMFA() {
+        let prompt = "Enter the verification code from your provider to continue."
+        replaceContent(with: AnyView(
+            PlaidifyLinkMFAView(prompt: prompt) { [weak self] _ in
+                self?.flow.apply(.mfaSubmitted)
+            }
+        ))
+    }
+
+    private func showProgress(_ title: String) {
+        replaceContent(with: AnyView(PlaidifyLinkProgressView(title: title)))
+    }
+
+    private func showError(_ message: String) {
+        replaceContent(with: AnyView(
+            PlaidifyLinkErrorView(message: message) { [weak self] in
+                self?.flow.apply(.reset)
+                self?.showPicker()
+            }
+        ))
+    }
+
+    // MARK: - Webview fallback
+
+    private func presentWebViewFallback() {
+        let handler = PlaidifyLinkScriptMessageHandler { [weak self] event in
+            self?.onEvent(event)
+            if event.shouldDismissSheet {
+                self?.dismiss(animated: true)
+            }
+        }
+        let webView = PlaidifyLinkWebViewFactory.makeWebView(
+            hostedLink: hostedConfiguration,
+            messageHandler: handler
+        )
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        view.subviews.forEach { $0.removeFromSuperview() }
+        children.forEach {
+            $0.willMove(toParent: nil)
+            $0.removeFromParent()
+        }
+        view.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        ])
+        self.webView = webView
+        self.messageHandler = handler
+    }
+
+    // MARK: - Helpers
+
+    private func replaceContent(with view: AnyView) {
+        if let hosting = hostingController {
+            hosting.rootView = view
+            return
+        }
+        let hosting = UIHostingController(rootView: view)
+        addChild(hosting)
+        hosting.view.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(hosting.view)
+        NSLayoutConstraint.activate([
+            hosting.view.topAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.topAnchor),
+            hosting.view.bottomAnchor.constraint(equalTo: self.view.safeAreaLayoutGuide.bottomAnchor),
+            hosting.view.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            hosting.view.trailingAnchor.constraint(equalTo: self.view.trailingAnchor),
+        ])
+        hosting.didMove(toParent: self)
+        hostingController = hosting
+    }
+
+    private func translate(_ flowEvent: PlaidifyLinkFlowEvent) {
+        switch flowEvent {
+        case .stepChanged(let step):
+            switch step {
+            case .picker: showPicker()
+            case .credentials:
+                if let org = flow.state.organization { showCredentials(for: org) }
+            case .connecting: showProgress("Connecting…")
+            case .mfa: showMFA()
+            case .success: showProgress("Connected.")
+            case .error:
+                showError(flow.state.lastErrorMessage ?? "Connection failed.")
+            case .consent:
+                break
+            }
+        case .institutionSelected(let org):
+            onEvent(PlaidifyLinkEvent(
+                source: "plaidify-link",
+                event: PlaidifyLinkEventName.institutionSelected.rawValue,
+                jobID: nil, publicToken: nil,
+                organizationID: org.organizationID,
+                organizationName: org.name, site: org.site,
+                mfaType: nil, sessionID: nil, error: nil, reason: nil
+            ))
+        case .mfaRequired(let type, let sessionID):
+            onEvent(PlaidifyLinkEvent(
+                source: "plaidify-link",
+                event: PlaidifyLinkEventName.mfaRequired.rawValue,
+                jobID: nil, publicToken: nil,
+                organizationID: flow.state.organization?.organizationID,
+                organizationName: flow.state.organization?.name,
+                site: flow.state.organization?.site,
+                mfaType: type, sessionID: sessionID, error: nil, reason: nil
+            ))
+        case .connected(let publicToken, let jobID, let site):
+            onEvent(PlaidifyLinkEvent(
+                source: "plaidify-link",
+                event: PlaidifyLinkEventName.connected.rawValue,
+                jobID: jobID, publicToken: publicToken,
+                organizationID: flow.state.organization?.organizationID,
+                organizationName: flow.state.organization?.name,
+                site: site,
+                mfaType: nil, sessionID: nil, error: nil, reason: nil
+            ))
+        case .errored(let code, let message):
+            onEvent(PlaidifyLinkEvent(
+                source: "plaidify-link",
+                event: PlaidifyLinkEventName.error.rawValue,
+                jobID: nil, publicToken: nil,
+                organizationID: flow.state.organization?.organizationID,
+                organizationName: flow.state.organization?.name,
+                site: flow.state.organization?.site,
+                mfaType: nil, sessionID: nil,
+                error: "\(code ?? "unknown"): \(message)",
+                reason: code
+            ))
+        case .fallbackToWebView(_, let reason):
+            onEvent(PlaidifyLinkEvent(
+                source: "plaidify-link",
+                event: "FALLBACK_WEBVIEW",
+                jobID: nil, publicToken: nil,
+                organizationID: flow.state.organization?.organizationID,
+                organizationName: flow.state.organization?.name,
+                site: flow.state.organization?.site,
+                mfaType: nil, sessionID: nil, error: nil, reason: reason
+            ))
+            presentWebViewFallback()
+        }
+    }
+}
+#endif

--- a/sdk-swift/Tests/PlaidifyLinkKitTests/PlaidifyLinkClientTests.swift
+++ b/sdk-swift/Tests/PlaidifyLinkKitTests/PlaidifyLinkClientTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import XCTest
+@testable import PlaidifyLinkKit
+
+final class PlaidifyLinkClientTests: XCTestCase {
+    func testStatusURLEscapesToken() {
+        let url = PlaidifyLinkURLBuilder.status(
+            serverURL: URL(string: "https://api.example.com/")!,
+            linkToken: "tok/with space"
+        )
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://api.example.com/link/sessions/tok/with%20space/status"
+        )
+    }
+
+    func testOrganizationSearchEncodesQuery() {
+        let url = PlaidifyLinkURLBuilder.organizationSearch(
+            serverURL: URL(string: "https://api.example.com")!,
+            query: "Royal Bank",
+            site: "rbc",
+            limit: 25
+        )
+        let absolute = url?.absoluteString ?? ""
+        XCTAssertTrue(absolute.hasPrefix("https://api.example.com/organizations/search?"))
+        XCTAssertTrue(absolute.contains("limit=25"))
+        XCTAssertTrue(absolute.contains("q=Royal%20Bank"))
+        XCTAssertTrue(absolute.contains("site=rbc"))
+    }
+
+    func testMFASubmitURL() {
+        let url = PlaidifyLinkURLBuilder.mfaSubmit(
+            serverURL: URL(string: "https://api.example.com")!,
+            sessionID: "sess-1",
+            code: "123456"
+        )
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://api.example.com/mfa/submit?session_id=sess-1&code=123456"
+        )
+    }
+
+    func testGetStatusDecodesPayload() async throws {
+        let stub = StubHTTPClient(responses: [
+            .ok(json: """
+                {"status":"awaiting_credentials","site":"rbc","mfa_type":null,"session_id":null,"public_token":null,"error_message":null}
+                """)
+        ])
+        let client = PlaidifyLinkClient(
+            serverURL: URL(string: "https://api.example.com")!,
+            linkToken: "tok",
+            http: stub
+        )
+        let status = try await client.getStatus()
+        XCTAssertEqual(status.status, "awaiting_credentials")
+        XCTAssertEqual(status.site, "rbc")
+    }
+
+    func testHTTPErrorIsTypedWithErrorCode() async {
+        let stub = StubHTTPClient(responses: [
+            .status(429, json: #"{"detail":"slow down","error_code":"rate_limited"}"#)
+        ])
+        let client = PlaidifyLinkClient(
+            serverURL: URL(string: "https://api.example.com")!,
+            linkToken: "tok",
+            http: stub
+        )
+        do {
+            _ = try await client.getStatus()
+            XCTFail("expected error")
+        } catch let PlaidifyLinkClientError.http(status, errorCode, message) {
+            XCTAssertEqual(status, 429)
+            XCTAssertEqual(errorCode, "rate_limited")
+            XCTAssertEqual(message, "slow down")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    func testConnectPostsExpectedBody() async throws {
+        let stub = StubHTTPClient(responses: [
+            .ok(json: #"{"status":"completed","public_token":"public-1","job_id":"job-1"}"#)
+        ])
+        let client = PlaidifyLinkClient(
+            serverURL: URL(string: "https://api.example.com")!,
+            linkToken: "tok-abc",
+            http: stub
+        )
+        let response = try await client.connect(
+            site: "rbc",
+            encrypted: PlaidifyEncryptedCredentials(username: "u-enc", password: "p-enc")
+        )
+        XCTAssertEqual(response.status, "completed")
+        XCTAssertEqual(response.publicToken, "public-1")
+
+        let recorded = try XCTUnwrap(stub.recordedRequests.first)
+        XCTAssertEqual(recorded.httpMethod, "POST")
+        XCTAssertEqual(recorded.url?.path, "/connect")
+        let body = try XCTUnwrap(recorded.httpBody)
+        let parsed = try JSONSerialization.jsonObject(with: body) as? [String: String]
+        XCTAssertEqual(parsed?["link_token"], "tok-abc")
+        XCTAssertEqual(parsed?["site"], "rbc")
+        XCTAssertEqual(parsed?["encrypted_username"], "u-enc")
+        XCTAssertEqual(parsed?["encrypted_password"], "p-enc")
+    }
+}
+
+// MARK: - Test doubles
+
+final class StubHTTPClient: PlaidifyLinkHTTPClient {
+    enum Stub {
+        case ok(json: String)
+        case status(Int, json: String)
+    }
+
+    private var queue: [Stub]
+    private(set) var recordedRequests: [URLRequest] = []
+
+    init(responses: [Stub]) {
+        self.queue = responses
+    }
+
+    func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        recordedRequests.append(request)
+        guard !queue.isEmpty else {
+            throw URLError(.badServerResponse)
+        }
+        let next = queue.removeFirst()
+        let url = request.url ?? URL(string: "about:blank")!
+        switch next {
+        case .ok(let json):
+            let data = json.data(using: .utf8) ?? Data()
+            let response = HTTPURLResponse(
+                url: url, statusCode: 200, httpVersion: nil, headerFields: nil
+            )!
+            return (data, response)
+        case .status(let code, let json):
+            let data = json.data(using: .utf8) ?? Data()
+            let response = HTTPURLResponse(
+                url: url, statusCode: code, httpVersion: nil, headerFields: nil
+            )!
+            return (data, response)
+        }
+    }
+}

--- a/sdk-swift/Tests/PlaidifyLinkKitTests/PlaidifyLinkConnectFlowTests.swift
+++ b/sdk-swift/Tests/PlaidifyLinkKitTests/PlaidifyLinkConnectFlowTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import XCTest
+@testable import PlaidifyLinkKit
+
+final class PlaidifyLinkConnectFlowTests: XCTestCase {
+    private func makeOrg(
+        site: String = "rbc",
+        authStyle: String? = "username_password"
+    ) -> PlaidifyOrganization {
+        PlaidifyOrganization(
+            organizationID: "org_\(site)",
+            name: "Test \(site)",
+            site: site,
+            logoURL: nil,
+            primaryColor: nil,
+            accentColor: nil,
+            secondaryColor: nil,
+            hintCopy: nil,
+            authStyle: authStyle
+        )
+    }
+
+    func testHappyPathPickerToCredentialsToConnectingToSuccess() {
+        var events: [PlaidifyLinkFlowEvent] = []
+        let registry = PlaidifyLinkInstitutionRegistry(
+            supportedSites: ["rbc"],
+            supportedAuthStyles: ["username_password"]
+        )
+        let flow = PlaidifyLinkConnectFlow(registry: registry) { events.append($0) }
+
+        let org = makeOrg()
+        flow.apply(.selectInstitution(org))
+        XCTAssertEqual(flow.state.step, .credentials)
+        XCTAssertEqual(flow.state.organization, org)
+
+        flow.apply(.credentialsSubmitted)
+        XCTAssertEqual(flow.state.step, .connecting)
+
+        flow.apply(.connectResponded(PlaidifyConnectResponse(
+            status: "completed",
+            sessionID: nil, mfaType: nil,
+            publicToken: "public-1", jobID: "job-1",
+            message: nil, errorMessage: nil
+        )))
+        XCTAssertEqual(flow.state.step, .success)
+        XCTAssertEqual(flow.state.publicToken, "public-1")
+        XCTAssertTrue(events.contains(.connected(publicToken: "public-1", jobID: "job-1", site: "rbc")))
+    }
+
+    func testMFAResponseTransitionsAndIncludesType() {
+        let registry = PlaidifyLinkInstitutionRegistry(
+            supportedSites: ["rbc"],
+            supportedAuthStyles: ["username_password"]
+        )
+        let flow = PlaidifyLinkConnectFlow(registry: registry)
+        flow.apply(.selectInstitution(makeOrg()))
+        flow.apply(.credentialsSubmitted)
+        flow.apply(.connectResponded(PlaidifyConnectResponse(
+            status: "mfa_required",
+            sessionID: "sess-9", mfaType: "otp",
+            publicToken: nil, jobID: nil,
+            message: nil, errorMessage: nil
+        )))
+        XCTAssertEqual(flow.state.step, .mfa)
+        XCTAssertEqual(flow.state.sessionID, "sess-9")
+        XCTAssertEqual(flow.state.mfaType, "otp")
+    }
+
+    func testFallbackEmittedForUnsupportedAuthStyle() {
+        var events: [PlaidifyLinkFlowEvent] = []
+        let registry = PlaidifyLinkInstitutionRegistry(
+            supportedSites: ["rbc"],
+            supportedAuthStyles: ["username_password"]
+        )
+        let flow = PlaidifyLinkConnectFlow(registry: registry) { events.append($0) }
+
+        let oauthOrg = makeOrg(authStyle: "oauth_redirect")
+        flow.apply(.selectInstitution(oauthOrg))
+
+        // No native step transition; webview fallback emitted instead.
+        XCTAssertNotEqual(flow.state.step, .credentials)
+        XCTAssertTrue(events.contains(where: {
+            if case .fallbackToWebView(let org, let reason) = $0 {
+                return org == oauthOrg && reason.hasPrefix("auth_style_unsupported")
+            }
+            return false
+        }))
+    }
+
+    func testFallbackForSiteNotInRegistry() {
+        var events: [PlaidifyLinkFlowEvent] = []
+        let registry = PlaidifyLinkInstitutionRegistry(
+            supportedSites: ["rbc"],
+            supportedAuthStyles: ["username_password"]
+        )
+        let flow = PlaidifyLinkConnectFlow(registry: registry) { events.append($0) }
+        flow.apply(.selectInstitution(makeOrg(site: "td")))
+        XCTAssertTrue(events.contains(.fallbackToWebView(makeOrg(site: "td"), reason: "site_not_in_native_registry")))
+    }
+
+    func testErrorResponseTransitionsToErrorStep() {
+        let registry = PlaidifyLinkInstitutionRegistry(
+            supportedSites: ["rbc"],
+            supportedAuthStyles: ["username_password"]
+        )
+        let flow = PlaidifyLinkConnectFlow(registry: registry)
+        flow.apply(.selectInstitution(makeOrg()))
+        flow.apply(.credentialsSubmitted)
+        flow.apply(.connectResponded(PlaidifyConnectResponse(
+            status: "error",
+            sessionID: nil, mfaType: nil,
+            publicToken: nil, jobID: nil,
+            message: nil, errorMessage: "bad credentials"
+        )))
+        XCTAssertEqual(flow.state.step, .error)
+        XCTAssertEqual(flow.state.lastErrorMessage, "bad credentials")
+    }
+
+    func testResetReturnsToPicker() {
+        let registry = PlaidifyLinkInstitutionRegistry(
+            supportedSites: ["rbc"],
+            supportedAuthStyles: ["username_password"]
+        )
+        let flow = PlaidifyLinkConnectFlow(registry: registry)
+        flow.apply(.selectInstitution(makeOrg()))
+        flow.apply(.reset)
+        XCTAssertEqual(flow.state.step, .picker)
+        XCTAssertNil(flow.state.organization)
+    }
+
+    func testEmptyRegistryFallsBackForUnknownAuthStyle() {
+        let registry = PlaidifyLinkInstitutionRegistry()
+        let strategy = registry.strategy(for: PlaidifyOrganization(
+            organizationID: "1", name: "X", site: "x",
+            logoURL: nil, primaryColor: nil, accentColor: nil,
+            secondaryColor: nil, hintCopy: nil, authStyle: nil
+        ))
+        if case .webViewFallback = strategy { } else {
+            XCTFail("expected webViewFallback")
+        }
+    }
+}


### PR DESCRIPTION
Closes #58.

Adds first-class native iOS Link screens to `PlaidifyLinkKit`. Long-tail institutions transparently fall back to the existing `WKWebView` surface. All `PlaidifyLinkEvent` callbacks (`OPEN`, `INSTITUTION_SELECTED`, `CREDENTIALS_SUBMITTED`, `MFA_REQUIRED`, `MFA_SUBMITTED`, `CONNECTED`, `EXIT`, `ERROR`) are preserved across both paths.

## What's new
- `PlaidifyLinkClient` — async REST client (status / search / encryption key / connect / MFA submit) with a pluggable `PlaidifyLinkHTTPClient` protocol.
- `PlaidifyLinkURLBuilder` — pure URL helpers.
- `PlaidifyLinkConnectFlow` — picker → credentials → connecting → mfa → success/error state machine.
- `PlaidifyLinkInstitutionRegistry` — opt-in registry of sites + auth styles; defaults to webview fallback so each connector ships only after explicit opt-in.
- `PlaidifyLinkScreens.swift` — SwiftUI picker / credentials / MFA / progress / error (iOS 15+, macOS 13+).
- `PlaidifyLinkViewController` — UIKit entrypoint that hosts the SwiftUI flow and switches to `WKWebView` on `.webViewFallback`.

## Tests
- `swift test`: 18/18 pass on Apple Swift 6.0.3 (`arm64-apple-macosx15.0`).
- New: `PlaidifyLinkClientTests` (6), `PlaidifyLinkConnectFlowTests` (7).
- UIKit code is guarded with `#if canImport(UIKit) && !os(macOS)` so the package compiles cleanly on macOS hosts.

## Notes
- iOS Simulator runtime verification still requires Xcode; this PR validates the package via the macOS toolchain only. Hosting an Xcode CI lane is tracked separately.
- Encryption + the `/connect` POST happen in the host-app layer so the SDK does not need a WebCrypto-equivalent; the flow exposes `CREDENTIALS_SUBMITTED` and accepts the connect response back via `flow.apply(.connectResponded(...))`.
