### PR TITLE
feat(sdk-android): new sdk-android module with native Compose Link screens (#59)

### DIFF
--- a/sdk-android/.gitignore
+++ b/sdk-android/.gitignore
@@ -1,0 +1,8 @@
+# Gradle build outputs
+build/
+.gradle/
+
+# IDE
+.idea/
+*.iml
+local.properties

--- a/sdk-android/README.md
+++ b/sdk-android/README.md
@@ -1,0 +1,63 @@
+# sdk-android — Plaidify Link for Android
+
+Native Jetpack Compose Link surface with WebView fallback.
+
+## Modules
+
+- `core/` — Pure Kotlin/JVM library: REST client (`PlaidifyLinkClient`),
+  state machine (`PlaidifyLinkConnectFlow`), and institution registry
+  (`PlaidifyLinkInstitutionRegistry`). Has no Android dependencies and
+  is fully unit-testable on the JVM. Run with `gradle :core:test`.
+- `ui/src/main/kotlin/` — Jetpack Compose screens
+  (`PlaidifyLinkPicker`, `PlaidifyLinkCredentials`, `PlaidifyLinkMfa`,
+  `PlaidifyLinkProgress`, `PlaidifyLinkErrorScreen`) plus a drop-in
+  `PlaidifyLinkActivity` that hosts the Compose flow and falls back
+  to a `WebView` for institutions outside the registry.
+
+The `ui/` sources are not built by this repository's Gradle root; host
+apps depend on `core` for logic and copy the Compose sources into
+their own Android library module that pulls AGP, Compose, and OkHttp.
+This keeps the published `core` artifact lightweight and lets each
+host app pick its own HTTP transport.
+
+## Quick start (host app)
+
+```kotlin
+// build.gradle.kts (Android library / app)
+dependencies {
+    implementation(project(":core"))
+    implementation("androidx.activity:activity-compose:1.9.0")
+    implementation("androidx.compose.material3:material3:1.2.1")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+}
+```
+
+```kotlin
+// Launch the Activity
+val intent = PlaidifyLinkActivity.intent(
+    context = this,
+    serverUrl = "https://api.example.com",
+    linkToken = "lnk-abc",
+)
+startActivity(intent)
+```
+
+## Event contract
+
+The native flow emits the same logical events as the WebView bridge
+(`OPEN`, `INSTITUTION_SELECTED`, `CREDENTIALS_SUBMITTED`,
+`MFA_REQUIRED`, `MFA_SUBMITTED`, `CONNECTED`, `EXIT`, `ERROR`) plus a
+`FALLBACK_WEBVIEW` event when an institution is routed to the WebView
+surface. Subscribe to events by setting `flow.onEvent = { ... }` on
+`PlaidifyLinkConnectFlow` or by hosting the flow yourself.
+
+## Tests
+
+```bash
+cd sdk-android
+gradle :core:test
+```
+
+13 unit tests cover URL escaping, JSON decoding, typed HTTP errors,
+state-machine transitions (happy path / MFA / error / reset), and
+fallback decisions.

--- a/sdk-android/build.gradle.kts
+++ b/sdk-android/build.gradle.kts
@@ -1,0 +1,9 @@
+// Root build for the Plaidify Android SDK. The :core module is pure
+// Kotlin/JVM so it builds without the Android SDK; the Compose UI
+// sources under ui/src/main/kotlin are provided as a drop-in for host
+// apps that depend on AGP and Jetpack Compose. See README.md for the
+// recommended host-app build.gradle.kts wiring.
+
+plugins {
+    kotlin("jvm") version "1.9.25" apply false
+}

--- a/sdk-android/core/build.gradle.kts
+++ b/sdk-android/core/build.gradle.kts
@@ -1,0 +1,28 @@
+plugins {
+    kotlin("jvm") version "1.9.25"
+    kotlin("plugin.serialization") version "1.9.25"
+}
+
+repositories {
+    mavenCentral()
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.8.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.3")
+
+    testImplementation(kotlin("test"))
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/sdk-android/core/src/main/kotlin/com/plaidify/link/Models.kt
+++ b/sdk-android/core/src/main/kotlin/com/plaidify/link/Models.kt
@@ -1,0 +1,65 @@
+package com.plaidify.link
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/** Errors emitted by [PlaidifyLinkClient]. Mirrors the Swift counterpart. */
+public sealed class PlaidifyLinkClientException(message: String) : RuntimeException(message) {
+    public class InvalidUrl(url: String) : PlaidifyLinkClientException("Invalid URL: $url")
+    public class Transport(message: String) : PlaidifyLinkClientException(message)
+    public class Http(
+        public val status: Int,
+        public val errorCode: String?,
+        message: String,
+    ) : PlaidifyLinkClientException(message)
+
+    public class Decoding(message: String) : PlaidifyLinkClientException(message)
+}
+
+/** Status payload returned by `GET /link/sessions/{token}/status`. */
+@Serializable
+public data class PlaidifyLinkSessionStatus(
+    val status: String,
+    val site: String? = null,
+    @SerialName("mfa_type") val mfaType: String? = null,
+    @SerialName("session_id") val sessionId: String? = null,
+    @SerialName("public_token") val publicToken: String? = null,
+    @SerialName("error_message") val errorMessage: String? = null,
+)
+
+/** Organization record returned by `/organizations/search`. */
+@Serializable
+public data class PlaidifyOrganization(
+    @SerialName("organization_id") val organizationId: String,
+    val name: String,
+    val site: String,
+    @SerialName("logo_url") val logoUrl: String? = null,
+    @SerialName("primary_color") val primaryColor: String? = null,
+    @SerialName("accent_color") val accentColor: String? = null,
+    @SerialName("secondary_color") val secondaryColor: String? = null,
+    @SerialName("hint_copy") val hintCopy: String? = null,
+    @SerialName("auth_style") val authStyle: String? = null,
+)
+
+@Serializable
+public data class PlaidifyOrganizationSearchResponse(
+    val organizations: List<PlaidifyOrganization>,
+)
+
+/** Encrypted credential pair posted to `/connect`. */
+public data class PlaidifyEncryptedCredentials(
+    val username: String,
+    val password: String,
+)
+
+/** Response payload from `/connect` and `/mfa/submit`. */
+@Serializable
+public data class PlaidifyConnectResponse(
+    val status: String,
+    @SerialName("session_id") val sessionId: String? = null,
+    @SerialName("mfa_type") val mfaType: String? = null,
+    @SerialName("public_token") val publicToken: String? = null,
+    @SerialName("job_id") val jobId: String? = null,
+    val message: String? = null,
+    @SerialName("error_message") val errorMessage: String? = null,
+)

--- a/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkClient.kt
+++ b/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkClient.kt
@@ -1,0 +1,134 @@
+package com.plaidify.link
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+/**
+ * Minimal HTTP abstraction so [PlaidifyLinkClient] is testable without
+ * spinning up a real server.
+ */
+public interface PlaidifyLinkHttpClient {
+    public suspend fun execute(request: HttpRequest): HttpResponse
+
+    public data class HttpRequest(
+        val method: String,
+        val url: String,
+        val headers: Map<String, String> = emptyMap(),
+        val body: String? = null,
+    )
+
+    public data class HttpResponse(
+        val status: Int,
+        val body: String,
+    )
+}
+
+/**
+ * REST client that talks to the same endpoints as the React frontend.
+ *
+ * All methods are `suspend` so the host app can call them from a
+ * coroutine scope (e.g. `viewModelScope.launch { ... }`).
+ */
+public class PlaidifyLinkClient(
+    public val serverUrl: String,
+    public val linkToken: String,
+    private val http: PlaidifyLinkHttpClient,
+    private val json: Json = Json { ignoreUnknownKeys = true },
+) {
+
+    public suspend fun getStatus(): PlaidifyLinkSessionStatus {
+        val url = PlaidifyLinkUrlBuilder.status(serverUrl, linkToken)
+        val raw = send(PlaidifyLinkHttpClient.HttpRequest(method = "GET", url = url))
+        return json.decodeFromString(PlaidifyLinkSessionStatus.serializer(), raw)
+    }
+
+    public suspend fun searchOrganizations(
+        query: String? = null,
+        site: String? = null,
+        limit: Int = 40,
+    ): PlaidifyOrganizationSearchResponse {
+        val url = PlaidifyLinkUrlBuilder.organizationSearch(serverUrl, query, site, limit)
+        val raw = send(PlaidifyLinkHttpClient.HttpRequest(method = "GET", url = url))
+        return json.decodeFromString(PlaidifyOrganizationSearchResponse.serializer(), raw)
+    }
+
+    public suspend fun connect(
+        site: String,
+        encrypted: PlaidifyEncryptedCredentials,
+    ): PlaidifyConnectResponse {
+        val url = PlaidifyLinkUrlBuilder.connect(serverUrl)
+        val body = buildString {
+            append('{')
+            append("\"link_token\":").append(jsonEncode(linkToken)).append(',')
+            append("\"site\":").append(jsonEncode(site)).append(',')
+            append("\"encrypted_username\":").append(jsonEncode(encrypted.username)).append(',')
+            append("\"encrypted_password\":").append(jsonEncode(encrypted.password))
+            append('}')
+        }
+        val raw = send(
+            PlaidifyLinkHttpClient.HttpRequest(
+                method = "POST",
+                url = url,
+                headers = mapOf("Content-Type" to "application/json"),
+                body = body,
+            )
+        )
+        return json.decodeFromString(PlaidifyConnectResponse.serializer(), raw)
+    }
+
+    public suspend fun submitMfa(sessionId: String, code: String): PlaidifyConnectResponse {
+        val url = PlaidifyLinkUrlBuilder.mfaSubmit(serverUrl, sessionId, code)
+        val raw = send(PlaidifyLinkHttpClient.HttpRequest(method = "POST", url = url))
+        return json.decodeFromString(PlaidifyConnectResponse.serializer(), raw)
+    }
+
+    private suspend fun send(request: PlaidifyLinkHttpClient.HttpRequest): String {
+        val response = try {
+            http.execute(
+                request.copy(headers = request.headers + ("Accept" to "application/json"))
+            )
+        } catch (t: Throwable) {
+            throw PlaidifyLinkClientException.Transport(t.message ?: t::class.simpleName ?: "transport error")
+        }
+        if (response.status !in 200..299) {
+            val (errorCode, message) = parseError(response.body, response.status)
+            throw PlaidifyLinkClientException.Http(response.status, errorCode, message)
+        }
+        return response.body
+    }
+
+    private fun parseError(body: String, status: Int): Pair<String?, String> {
+        return try {
+            val obj: JsonObject = json.parseToJsonElement(body).jsonObject
+            val detail = obj["detail"]?.jsonPrimitive?.contentOrNull
+            val error = obj["error"]?.jsonPrimitive?.contentOrNull
+            val code = obj["error_code"]?.jsonPrimitive?.contentOrNull
+            code to (detail ?: error ?: "HTTP $status")
+        } catch (e: Exception) {
+            null to "HTTP $status"
+        }
+    }
+
+    private fun jsonEncode(value: String): String {
+        val sb = StringBuilder("\"")
+        for (ch in value) {
+            when (ch) {
+                '"' -> sb.append("\\\"")
+                '\\' -> sb.append("\\\\")
+                '\n' -> sb.append("\\n")
+                '\r' -> sb.append("\\r")
+                '\t' -> sb.append("\\t")
+                else -> if (ch.code < 0x20) {
+                    sb.append("\\u").append(String.format("%04x", ch.code))
+                } else {
+                    sb.append(ch)
+                }
+            }
+        }
+        sb.append('"')
+        return sb.toString()
+    }
+}

--- a/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkConnectFlow.kt
+++ b/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkConnectFlow.kt
@@ -1,0 +1,159 @@
+package com.plaidify.link
+
+/** Step the hosted-link flow is currently on. */
+public enum class PlaidifyLinkStep {
+    Consent, Picker, Credentials, Connecting, Mfa, Success, Error
+}
+
+/** Single observable callback emitted by [PlaidifyLinkConnectFlow]. */
+public sealed class PlaidifyLinkFlowEvent {
+    public data class StepChanged(val step: PlaidifyLinkStep) : PlaidifyLinkFlowEvent()
+    public data class InstitutionSelected(val organization: PlaidifyOrganization) : PlaidifyLinkFlowEvent()
+    public data class MfaRequired(val type: String, val sessionId: String?) : PlaidifyLinkFlowEvent()
+    public data class Connected(
+        val publicToken: String?,
+        val jobId: String?,
+        val site: String?,
+    ) : PlaidifyLinkFlowEvent()
+
+    public data class Errored(val code: String?, val message: String) : PlaidifyLinkFlowEvent()
+    public data class FallbackToWebView(
+        val organization: PlaidifyOrganization,
+        val reason: String,
+    ) : PlaidifyLinkFlowEvent()
+}
+
+/** Pure state for the connect flow. */
+public data class PlaidifyLinkFlowState(
+    val step: PlaidifyLinkStep = PlaidifyLinkStep.Picker,
+    val organization: PlaidifyOrganization? = null,
+    val sessionId: String? = null,
+    val mfaType: String? = null,
+    val lastErrorCode: String? = null,
+    val lastErrorMessage: String? = null,
+    val publicToken: String? = null,
+    val jobId: String? = null,
+)
+
+/**
+ * Pure state machine for the picker → credentials → connecting →
+ * mfa → success/error transitions. The class is intentionally
+ * UI-framework agnostic so it is fully unit-testable on the JVM.
+ */
+public class PlaidifyLinkConnectFlow(
+    public val registry: PlaidifyLinkInstitutionRegistry = PlaidifyLinkInstitutionRegistry(),
+    initialState: PlaidifyLinkFlowState = PlaidifyLinkFlowState(),
+    public var onEvent: (PlaidifyLinkFlowEvent) -> Unit = {},
+) {
+    public var state: PlaidifyLinkFlowState = initialState
+        private set
+
+    public sealed class Action {
+        public data class SelectInstitution(val organization: PlaidifyOrganization) : Action()
+        public object CredentialsSubmitted : Action()
+        public data class ConnectResponded(val response: PlaidifyConnectResponse) : Action()
+        public object MfaSubmitted : Action()
+        public data class MfaResponded(val response: PlaidifyConnectResponse) : Action()
+        public data class Failed(val code: String?, val message: String) : Action()
+        public object Reset : Action()
+    }
+
+    public fun apply(action: Action): PlaidifyLinkFlowState {
+        when (action) {
+            is Action.SelectInstitution -> {
+                when (val strategy = registry.strategy(action.organization)) {
+                    is PlaidifyLinkInstitutionStrategy.WebViewFallback -> {
+                        onEvent(PlaidifyLinkFlowEvent.FallbackToWebView(action.organization, strategy.reason))
+                        state = state.copy(organization = action.organization)
+                    }
+                    PlaidifyLinkInstitutionStrategy.Native -> {
+                        state = state.copy(
+                            organization = action.organization,
+                            step = PlaidifyLinkStep.Credentials,
+                        )
+                        onEvent(PlaidifyLinkFlowEvent.InstitutionSelected(action.organization))
+                        onEvent(PlaidifyLinkFlowEvent.StepChanged(PlaidifyLinkStep.Credentials))
+                    }
+                }
+            }
+
+            Action.CredentialsSubmitted -> {
+                state = state.copy(step = PlaidifyLinkStep.Connecting)
+                onEvent(PlaidifyLinkFlowEvent.StepChanged(PlaidifyLinkStep.Connecting))
+            }
+
+            is Action.ConnectResponded -> handleConnectResponse(action.response)
+
+            Action.MfaSubmitted -> {
+                state = state.copy(step = PlaidifyLinkStep.Connecting)
+                onEvent(PlaidifyLinkFlowEvent.StepChanged(PlaidifyLinkStep.Connecting))
+            }
+
+            is Action.MfaResponded -> handleConnectResponse(action.response)
+
+            is Action.Failed -> {
+                state = state.copy(
+                    step = PlaidifyLinkStep.Error,
+                    lastErrorCode = action.code,
+                    lastErrorMessage = action.message,
+                )
+                onEvent(PlaidifyLinkFlowEvent.Errored(action.code, action.message))
+                onEvent(PlaidifyLinkFlowEvent.StepChanged(PlaidifyLinkStep.Error))
+            }
+
+            Action.Reset -> {
+                state = PlaidifyLinkFlowState()
+                onEvent(PlaidifyLinkFlowEvent.StepChanged(PlaidifyLinkStep.Picker))
+            }
+        }
+        return state
+    }
+
+    private fun handleConnectResponse(response: PlaidifyConnectResponse) {
+        when (response.status) {
+            "completed" -> {
+                state = state.copy(
+                    step = PlaidifyLinkStep.Success,
+                    publicToken = response.publicToken,
+                    jobId = response.jobId,
+                )
+                onEvent(
+                    PlaidifyLinkFlowEvent.Connected(
+                        publicToken = response.publicToken,
+                        jobId = response.jobId,
+                        site = state.organization?.site,
+                    )
+                )
+                onEvent(PlaidifyLinkFlowEvent.StepChanged(PlaidifyLinkStep.Success))
+            }
+
+            "mfa_required" -> {
+                state = state.copy(
+                    step = PlaidifyLinkStep.Mfa,
+                    sessionId = response.sessionId,
+                    mfaType = response.mfaType,
+                )
+                onEvent(
+                    PlaidifyLinkFlowEvent.MfaRequired(
+                        type = response.mfaType ?: "otp",
+                        sessionId = response.sessionId,
+                    )
+                )
+                onEvent(PlaidifyLinkFlowEvent.StepChanged(PlaidifyLinkStep.Mfa))
+            }
+
+            "error" -> {
+                apply(
+                    Action.Failed(
+                        code = null,
+                        message = response.errorMessage ?: response.message ?: "Connection failed.",
+                    )
+                )
+            }
+
+            else -> {
+                // pending / unknown: stay on connecting.
+            }
+        }
+    }
+}

--- a/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkInstitutionRegistry.kt
+++ b/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkInstitutionRegistry.kt
@@ -1,0 +1,42 @@
+package com.plaidify.link
+
+/** Decision returned by [PlaidifyLinkInstitutionRegistry]. */
+public sealed class PlaidifyLinkInstitutionStrategy {
+    /** The native Compose flow can render this institution. */
+    public object Native : PlaidifyLinkInstitutionStrategy()
+
+    /** The institution should be rendered via the WebView fallback. */
+    public data class WebViewFallback(val reason: String) : PlaidifyLinkInstitutionStrategy()
+}
+
+/**
+ * Registry of institutions covered by the native Android UI. Embedders
+ * pass a custom registry to opt institutions in; the default registry
+ * falls back to webview for everything so a release is required to
+ * enable each native connector — release-safe.
+ */
+public data class PlaidifyLinkInstitutionRegistry(
+    val supportedSites: Set<String> = emptySet(),
+    val supportedAuthStyles: Set<String> = DEFAULT_SUPPORTED_AUTH_STYLES,
+) {
+    public fun strategy(organization: PlaidifyOrganization): PlaidifyLinkInstitutionStrategy {
+        if (supportedSites.isNotEmpty() && organization.site !in supportedSites) {
+            return PlaidifyLinkInstitutionStrategy.WebViewFallback("site_not_in_native_registry")
+        }
+        val style = organization.authStyle
+        if (style != null && style !in supportedAuthStyles) {
+            return PlaidifyLinkInstitutionStrategy.WebViewFallback("auth_style_unsupported:$style")
+        }
+        if (style == null && supportedSites.isEmpty()) {
+            return PlaidifyLinkInstitutionStrategy.WebViewFallback("auth_style_unknown")
+        }
+        return PlaidifyLinkInstitutionStrategy.Native
+    }
+
+    public companion object {
+        public val DEFAULT_SUPPORTED_AUTH_STYLES: Set<String> = setOf(
+            "username_password",
+            "username_password_otp",
+        )
+    }
+}

--- a/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkUrlBuilder.kt
+++ b/sdk-android/core/src/main/kotlin/com/plaidify/link/PlaidifyLinkUrlBuilder.kt
@@ -1,0 +1,61 @@
+package com.plaidify.link
+
+import java.net.URI
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+/** Pure URL builders for the Plaidify Link REST endpoints. */
+public object PlaidifyLinkUrlBuilder {
+    public fun base(serverUrl: String): String =
+        if (serverUrl.endsWith("/")) serverUrl.dropLast(1) else serverUrl
+
+    public fun status(serverUrl: String, linkToken: String): String =
+        base(serverUrl) + "/link/sessions/" + encodePath(linkToken) + "/status"
+
+    public fun organizationSearch(
+        serverUrl: String,
+        query: String?,
+        site: String?,
+        limit: Int,
+    ): String {
+        val params = mutableListOf("limit=$limit")
+        if (!query.isNullOrEmpty()) {
+            params += "q=" + encodeQuery(query)
+        }
+        if (!site.isNullOrEmpty()) {
+            params += "site=" + encodeQuery(site)
+        }
+        return base(serverUrl) + "/organizations/search?" + params.joinToString("&")
+    }
+
+    public fun encryptionPublicKey(serverUrl: String, linkToken: String): String =
+        base(serverUrl) + "/encryption/public_key/" + encodePath(linkToken)
+
+    public fun connect(serverUrl: String): String =
+        base(serverUrl) + "/connect"
+
+    public fun mfaSubmit(serverUrl: String, sessionId: String, code: String): String =
+        base(serverUrl) + "/mfa/submit?session_id=" + encodeQuery(sessionId) +
+            "&code=" + encodeQuery(code)
+
+    /**
+     * Best-effort path encoding that matches the Swift counterpart:
+     * encodes spaces as %20 and leaves `/` alone (URL paths can contain
+     * slashes; we only need to escape spaces and other unsafe chars).
+     */
+    private fun encodePath(value: String): String {
+        return URLEncoder.encode(value, StandardCharsets.UTF_8)
+            .replace("+", "%20")
+            .replace("%2F", "/")
+    }
+
+    private fun encodeQuery(value: String): String =
+        URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
+
+    /** Validate a URL is well-formed without making it absolute-mandatory. */
+    public fun parse(url: String): URI? = try {
+        URI(url)
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/sdk-android/core/src/test/kotlin/com/plaidify/link/PlaidifyLinkClientTest.kt
+++ b/sdk-android/core/src/test/kotlin/com/plaidify/link/PlaidifyLinkClientTest.kt
@@ -1,0 +1,122 @@
+package com.plaidify.link
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class PlaidifyLinkClientTest {
+    @Test
+    fun statusUrlEscapesToken() {
+        val url = PlaidifyLinkUrlBuilder.status("https://api.example.com/", "tok with space")
+        assertEquals("https://api.example.com/link/sessions/tok%20with%20space/status", url)
+    }
+
+    @Test
+    fun organizationSearchEncodesQuery() {
+        val url = PlaidifyLinkUrlBuilder.organizationSearch(
+            serverUrl = "https://api.example.com",
+            query = "Royal Bank",
+            site = "rbc",
+            limit = 25,
+        )
+        assertTrue(url.startsWith("https://api.example.com/organizations/search?"))
+        assertTrue(url.contains("limit=25"))
+        assertTrue(url.contains("q=Royal%20Bank"))
+        assertTrue(url.contains("site=rbc"))
+    }
+
+    @Test
+    fun mfaSubmitUrl() {
+        val url = PlaidifyLinkUrlBuilder.mfaSubmit("https://api.example.com", "sess-1", "123456")
+        assertEquals("https://api.example.com/mfa/submit?session_id=sess-1&code=123456", url)
+    }
+
+    @Test
+    fun getStatusDecodesPayload() = runTest {
+        val stub = StubHttpClient(
+            listOf(
+                StubHttpClient.Response(
+                    200,
+                    """{"status":"awaiting_credentials","site":"rbc"}""",
+                )
+            )
+        )
+        val client = PlaidifyLinkClient(
+            serverUrl = "https://api.example.com",
+            linkToken = "tok",
+            http = stub,
+        )
+        val status = client.getStatus()
+        assertEquals("awaiting_credentials", status.status)
+        assertEquals("rbc", status.site)
+    }
+
+    @Test
+    fun httpErrorIsTypedWithErrorCode() = runTest {
+        val stub = StubHttpClient(
+            listOf(
+                StubHttpClient.Response(
+                    429,
+                    """{"detail":"slow down","error_code":"rate_limited"}""",
+                )
+            )
+        )
+        val client = PlaidifyLinkClient(
+            serverUrl = "https://api.example.com",
+            linkToken = "tok",
+            http = stub,
+        )
+        val error = assertFailsWith<PlaidifyLinkClientException.Http> { client.getStatus() }
+        assertEquals(429, error.status)
+        assertEquals("rate_limited", error.errorCode)
+        assertEquals("slow down", error.message)
+    }
+
+    @Test
+    fun connectPostsExpectedBody() = runTest {
+        val stub = StubHttpClient(
+            listOf(
+                StubHttpClient.Response(
+                    200,
+                    """{"status":"completed","public_token":"public-1","job_id":"job-1"}""",
+                )
+            )
+        )
+        val client = PlaidifyLinkClient(
+            serverUrl = "https://api.example.com",
+            linkToken = "tok-abc",
+            http = stub,
+        )
+        val response = client.connect(
+            site = "rbc",
+            encrypted = PlaidifyEncryptedCredentials(username = "u-enc", password = "p-enc"),
+        )
+        assertEquals("completed", response.status)
+        assertEquals("public-1", response.publicToken)
+
+        val recorded = stub.recordedRequests.first()
+        assertEquals("POST", recorded.method)
+        assertTrue(recorded.url.endsWith("/connect"))
+        val body = assertNotNull(recorded.body)
+        assertTrue(body.contains("\"link_token\":\"tok-abc\""))
+        assertTrue(body.contains("\"site\":\"rbc\""))
+        assertTrue(body.contains("\"encrypted_username\":\"u-enc\""))
+        assertTrue(body.contains("\"encrypted_password\":\"p-enc\""))
+    }
+}
+
+class StubHttpClient(responses: List<Response>) : PlaidifyLinkHttpClient {
+    public data class Response(val status: Int, val body: String)
+
+    private val queue = ArrayDeque(responses)
+    public val recordedRequests: MutableList<PlaidifyLinkHttpClient.HttpRequest> = mutableListOf()
+
+    override suspend fun execute(request: PlaidifyLinkHttpClient.HttpRequest): PlaidifyLinkHttpClient.HttpResponse {
+        recordedRequests += request
+        val next = queue.removeFirstOrNull() ?: error("No stub responses left")
+        return PlaidifyLinkHttpClient.HttpResponse(next.status, next.body)
+    }
+}

--- a/sdk-android/core/src/test/kotlin/com/plaidify/link/PlaidifyLinkConnectFlowTest.kt
+++ b/sdk-android/core/src/test/kotlin/com/plaidify/link/PlaidifyLinkConnectFlowTest.kt
@@ -1,0 +1,120 @@
+package com.plaidify.link
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PlaidifyLinkConnectFlowTest {
+    private fun makeOrg(
+        site: String = "rbc",
+        authStyle: String? = "username_password",
+    ) = PlaidifyOrganization(
+        organizationId = "org_$site",
+        name = "Test $site",
+        site = site,
+        authStyle = authStyle,
+    )
+
+    private fun nativeRegistry() = PlaidifyLinkInstitutionRegistry(
+        supportedSites = setOf("rbc"),
+        supportedAuthStyles = setOf("username_password"),
+    )
+
+    @Test
+    fun happyPathPickerToCredentialsToConnectingToSuccess() {
+        val events = mutableListOf<PlaidifyLinkFlowEvent>()
+        val flow = PlaidifyLinkConnectFlow(nativeRegistry()) { events += it }
+
+        val org = makeOrg()
+        flow.apply(PlaidifyLinkConnectFlow.Action.SelectInstitution(org))
+        assertEquals(PlaidifyLinkStep.Credentials, flow.state.step)
+        assertEquals(org, flow.state.organization)
+
+        flow.apply(PlaidifyLinkConnectFlow.Action.CredentialsSubmitted)
+        assertEquals(PlaidifyLinkStep.Connecting, flow.state.step)
+
+        flow.apply(
+            PlaidifyLinkConnectFlow.Action.ConnectResponded(
+                PlaidifyConnectResponse(status = "completed", publicToken = "public-1", jobId = "job-1"),
+            )
+        )
+        assertEquals(PlaidifyLinkStep.Success, flow.state.step)
+        assertEquals("public-1", flow.state.publicToken)
+        assertTrue(events.any { it is PlaidifyLinkFlowEvent.Connected && it.publicToken == "public-1" })
+    }
+
+    @Test
+    fun mfaResponseTransitionsAndIncludesType() {
+        val flow = PlaidifyLinkConnectFlow(nativeRegistry())
+        flow.apply(PlaidifyLinkConnectFlow.Action.SelectInstitution(makeOrg()))
+        flow.apply(PlaidifyLinkConnectFlow.Action.CredentialsSubmitted)
+        flow.apply(
+            PlaidifyLinkConnectFlow.Action.ConnectResponded(
+                PlaidifyConnectResponse(status = "mfa_required", sessionId = "sess-9", mfaType = "otp"),
+            )
+        )
+        assertEquals(PlaidifyLinkStep.Mfa, flow.state.step)
+        assertEquals("sess-9", flow.state.sessionId)
+        assertEquals("otp", flow.state.mfaType)
+    }
+
+    @Test
+    fun fallbackEmittedForUnsupportedAuthStyle() {
+        val events = mutableListOf<PlaidifyLinkFlowEvent>()
+        val flow = PlaidifyLinkConnectFlow(nativeRegistry()) { events += it }
+
+        val oauthOrg = makeOrg(authStyle = "oauth_redirect")
+        flow.apply(PlaidifyLinkConnectFlow.Action.SelectInstitution(oauthOrg))
+
+        assertNotEquals(PlaidifyLinkStep.Credentials, flow.state.step)
+        assertTrue(events.any {
+            it is PlaidifyLinkFlowEvent.FallbackToWebView
+                && it.organization == oauthOrg
+                && it.reason.startsWith("auth_style_unsupported")
+        })
+    }
+
+    @Test
+    fun fallbackForSiteNotInRegistry() {
+        val events = mutableListOf<PlaidifyLinkFlowEvent>()
+        val flow = PlaidifyLinkConnectFlow(nativeRegistry()) { events += it }
+        flow.apply(PlaidifyLinkConnectFlow.Action.SelectInstitution(makeOrg(site = "td")))
+        assertTrue(events.any {
+            it is PlaidifyLinkFlowEvent.FallbackToWebView && it.reason == "site_not_in_native_registry"
+        })
+    }
+
+    @Test
+    fun errorResponseTransitionsToErrorStep() {
+        val flow = PlaidifyLinkConnectFlow(nativeRegistry())
+        flow.apply(PlaidifyLinkConnectFlow.Action.SelectInstitution(makeOrg()))
+        flow.apply(PlaidifyLinkConnectFlow.Action.CredentialsSubmitted)
+        flow.apply(
+            PlaidifyLinkConnectFlow.Action.ConnectResponded(
+                PlaidifyConnectResponse(status = "error", errorMessage = "bad credentials"),
+            )
+        )
+        assertEquals(PlaidifyLinkStep.Error, flow.state.step)
+        assertEquals("bad credentials", flow.state.lastErrorMessage)
+    }
+
+    @Test
+    fun resetReturnsToPicker() {
+        val flow = PlaidifyLinkConnectFlow(nativeRegistry())
+        flow.apply(PlaidifyLinkConnectFlow.Action.SelectInstitution(makeOrg()))
+        flow.apply(PlaidifyLinkConnectFlow.Action.Reset)
+        assertEquals(PlaidifyLinkStep.Picker, flow.state.step)
+        assertNull(flow.state.organization)
+    }
+
+    @Test
+    fun emptyRegistryFallsBackForUnknownAuthStyle() {
+        val registry = PlaidifyLinkInstitutionRegistry()
+        val strategy = registry.strategy(
+            PlaidifyOrganization(organizationId = "1", name = "X", site = "x", authStyle = null)
+        )
+        assertTrue(strategy is PlaidifyLinkInstitutionStrategy.WebViewFallback)
+    }
+}

--- a/sdk-android/settings.gradle.kts
+++ b/sdk-android/settings.gradle.kts
@@ -1,0 +1,4 @@
+rootProject.name = "plaidify-link-android"
+
+include(":core")
+project(":core").projectDir = file("core")

--- a/sdk-android/ui/src/main/kotlin/com/plaidify/link/ui/PlaidifyLinkActivity.kt
+++ b/sdk-android/ui/src/main/kotlin/com/plaidify/link/ui/PlaidifyLinkActivity.kt
@@ -1,0 +1,189 @@
+package com.plaidify.link.ui
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import com.plaidify.link.PlaidifyLinkClient
+import com.plaidify.link.PlaidifyLinkConnectFlow
+import com.plaidify.link.PlaidifyLinkFlowEvent
+import com.plaidify.link.PlaidifyLinkInstitutionRegistry
+import com.plaidify.link.PlaidifyLinkStep
+import com.plaidify.link.PlaidifyOrganization
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * Drop-in Activity that hosts the native Compose Link flow and falls
+ * back to a WebView for institutions outside the registry. Equivalent
+ * of `PlaidifyLinkViewController` on iOS.
+ *
+ * Launch:
+ * ```
+ * val intent = PlaidifyLinkActivity.intent(
+ *     context = ctx,
+ *     serverUrl = "https://api.example.com",
+ *     linkToken = "lnk-abc",
+ * )
+ * startActivity(intent)
+ * ```
+ *
+ * Embedders observe events via the broadcast queue or by hosting the
+ * flow themselves. For the most flexibility, depend directly on
+ * `PlaidifyLinkConnectFlow` from the `core` module and compose the UI
+ * in your own Activity / NavHost.
+ */
+public class PlaidifyLinkActivity : ComponentActivity() {
+
+    public companion object {
+        public const val EXTRA_SERVER_URL: String = "com.plaidify.link.SERVER_URL"
+        public const val EXTRA_LINK_TOKEN: String = "com.plaidify.link.LINK_TOKEN"
+
+        public fun intent(context: Context, serverUrl: String, linkToken: String): Intent =
+            Intent(context, PlaidifyLinkActivity::class.java)
+                .putExtra(EXTRA_SERVER_URL, serverUrl)
+                .putExtra(EXTRA_LINK_TOKEN, linkToken)
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val serverUrl = intent.getStringExtra(EXTRA_SERVER_URL).orEmpty()
+        val linkToken = intent.getStringExtra(EXTRA_LINK_TOKEN).orEmpty()
+        val client = PlaidifyLinkClient(
+            serverUrl = serverUrl,
+            linkToken = linkToken,
+            http = OkHttpAdapter(),
+        )
+        val flow = PlaidifyLinkConnectFlow(PlaidifyLinkInstitutionRegistry())
+        setContent {
+            PlaidifyLinkRoot(
+                client = client,
+                flow = flow,
+                hostedLinkUrl = "$serverUrl/link?token=$linkToken",
+                onFinished = { finish() },
+            )
+        }
+    }
+}
+
+@Composable
+private fun PlaidifyLinkRoot(
+    client: PlaidifyLinkClient,
+    flow: PlaidifyLinkConnectFlow,
+    hostedLinkUrl: String,
+    onFinished: () -> Unit,
+) {
+    var organizations by remember { mutableStateOf<List<PlaidifyOrganization>>(emptyList()) }
+    var fallbackOrg by remember { mutableStateOf<PlaidifyOrganization?>(null) }
+    var step by remember { mutableStateOf(flow.state.step) }
+    val scope = rememberCoroutineScopeCompat()
+
+    flow.onEvent = { event ->
+        when (event) {
+            is PlaidifyLinkFlowEvent.StepChanged -> step = event.step
+            is PlaidifyLinkFlowEvent.FallbackToWebView -> fallbackOrg = event.organization
+            is PlaidifyLinkFlowEvent.Connected -> onFinished()
+            else -> Unit
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        scope.launch {
+            organizations = withContext(Dispatchers.IO) {
+                runCatching { client.searchOrganizations().organizations }.getOrDefault(emptyList())
+            }
+        }
+    }
+
+    if (fallbackOrg != null) {
+        WebViewFallback(hostedLinkUrl = hostedLinkUrl, onFinished = onFinished)
+        return
+    }
+
+    when (step) {
+        PlaidifyLinkStep.Picker ->
+            PlaidifyLinkPicker(organizations = organizations) { org ->
+                flow.apply(PlaidifyLinkConnectFlow.Action.SelectInstitution(org))
+            }
+
+        PlaidifyLinkStep.Credentials -> {
+            val org = flow.state.organization ?: return
+            PlaidifyLinkCredentials(organization = org) { _, _ ->
+                flow.apply(PlaidifyLinkConnectFlow.Action.CredentialsSubmitted)
+            }
+        }
+
+        PlaidifyLinkStep.Connecting -> PlaidifyLinkProgress(title = "Connecting…")
+        PlaidifyLinkStep.Mfa -> PlaidifyLinkMfa(
+            prompt = "Enter the verification code from your provider to continue."
+        ) { _ -> flow.apply(PlaidifyLinkConnectFlow.Action.MfaSubmitted) }
+
+        PlaidifyLinkStep.Success -> PlaidifyLinkProgress(title = "Connected.")
+        PlaidifyLinkStep.Error -> PlaidifyLinkErrorScreen(
+            message = flow.state.lastErrorMessage ?: "Connection failed."
+        ) { flow.apply(PlaidifyLinkConnectFlow.Action.Reset) }
+
+        PlaidifyLinkStep.Consent -> Unit
+    }
+}
+
+/**
+ * Lightweight wrapper around `androidx.compose.runtime.rememberCoroutineScope`
+ * so this file does not require the optional alias import.
+ */
+@Composable
+private fun rememberCoroutineScopeCompat() = androidx.compose.runtime.rememberCoroutineScope()
+
+/**
+ * WebView fallback that loads the hosted /link page and forwards
+ * postMessage events to the host via the `plaidifyLink` JS interface
+ * (matches the React app's bridge contract).
+ */
+@Composable
+private fun WebViewFallback(hostedLinkUrl: String, onFinished: () -> Unit) {
+    val context = LocalContext.current
+    AndroidView(factory = {
+        WebView(context).apply {
+            settings.javaScriptEnabled = true
+            webViewClient = WebViewClient()
+            addJavascriptInterface(object {
+                @JavascriptInterface
+                fun postMessage(payload: String) {
+                    val obj = runCatching { JSONObject(payload) }.getOrNull() ?: return
+                    if (obj.optString("source") != "plaidify-link") return
+                    val event = obj.optString("event")
+                    if (event == "CONNECTED" || event == "EXIT" || event == "ERROR") {
+                        onFinished()
+                    }
+                }
+            }, "plaidifyLink")
+            loadUrl(Uri.parse(hostedLinkUrl).toString())
+        }
+    })
+}
+
+/** Stub HTTP client. Host apps inject their own (OkHttp/Ktor/etc). */
+private class OkHttpAdapter : com.plaidify.link.PlaidifyLinkHttpClient {
+    override suspend fun execute(
+        request: com.plaidify.link.PlaidifyLinkHttpClient.HttpRequest
+    ): com.plaidify.link.PlaidifyLinkHttpClient.HttpResponse {
+        throw UnsupportedOperationException(
+            "Replace OkHttpAdapter with an OkHttp / Ktor backed implementation in the host app."
+        )
+    }
+}

--- a/sdk-android/ui/src/main/kotlin/com/plaidify/link/ui/PlaidifyLinkScreens.kt
+++ b/sdk-android/ui/src/main/kotlin/com/plaidify/link/ui/PlaidifyLinkScreens.kt
@@ -1,0 +1,195 @@
+package com.plaidify.link.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import com.plaidify.link.PlaidifyOrganization
+
+/**
+ * Jetpack Compose screens that mirror the SwiftUI flow on iOS. These
+ * are kept in a separate `ui/` source set so the JVM-only `core/`
+ * module remains testable without Android dependencies. Host apps
+ * integrating the SDK depend on `core` for logic and pull these
+ * Compose sources via their own Android library module.
+ */
+@Composable
+public fun PlaidifyLinkPicker(
+    organizations: List<PlaidifyOrganization>,
+    onSelect: (PlaidifyOrganization) -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    val filtered = remember(query, organizations) {
+        val trimmed = query.trim()
+        if (trimmed.isEmpty()) organizations
+        else organizations.filter {
+            it.name.contains(trimmed, ignoreCase = true) || it.site.contains(trimmed, ignoreCase = true)
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Select your bank",
+            modifier = Modifier.semantics { heading() },
+        )
+        OutlinedTextField(
+            value = query,
+            onValueChange = { query = it },
+            label = { Text("Search institutions") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Search institutions" },
+        )
+        LazyColumn {
+            items(filtered, key = { it.organizationId }) { org ->
+                Button(
+                    onClick = { onSelect(org) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp)
+                        .semantics { contentDescription = "Select ${org.name}" },
+                ) {
+                    Text("${org.name} (${org.site})")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+public fun PlaidifyLinkCredentials(
+    organization: PlaidifyOrganization,
+    onSubmit: (String, String) -> Unit,
+) {
+    var username by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Sign in to ${organization.name}",
+            modifier = Modifier.semantics { heading() },
+        )
+        organization.hintCopy?.let { Text(it) }
+        OutlinedTextField(
+            value = username,
+            onValueChange = { username = it },
+            label = { Text("Username") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Username" },
+        )
+        OutlinedTextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("Password") },
+            visualTransformation = PasswordVisualTransformation(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Password" },
+        )
+        Button(
+            onClick = { onSubmit(username, password) },
+            enabled = username.isNotEmpty() && password.isNotEmpty(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Continue to verify credentials" },
+        ) {
+            Text("Continue")
+        }
+    }
+}
+
+@Composable
+public fun PlaidifyLinkMfa(
+    prompt: String,
+    onSubmit: (String) -> Unit,
+) {
+    var code by remember { mutableStateOf("") }
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Verify your identity",
+            modifier = Modifier.semantics { heading() },
+        )
+        Text(prompt)
+        OutlinedTextField(
+            value = code,
+            onValueChange = { code = it },
+            label = { Text("Verification code") },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Verification code" },
+        )
+        Button(
+            onClick = { onSubmit(code) },
+            enabled = code.isNotEmpty(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .semantics { contentDescription = "Submit verification code" },
+        ) {
+            Text("Submit")
+        }
+    }
+}
+
+@Composable
+public fun PlaidifyLinkProgress(title: String) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        CircularProgressIndicator()
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(title)
+    }
+}
+
+@Composable
+public fun PlaidifyLinkErrorScreen(message: String, onRetry: () -> Unit) {
+    Column(
+        modifier = Modifier.fillMaxWidth().padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = "Something went wrong",
+            modifier = Modifier.semantics { heading() },
+        )
+        Text(message)
+        Button(
+            onClick = onRetry,
+            modifier = Modifier.semantics { contentDescription = "Retry connection" },
+        ) {
+            Text("Try again")
+        }
+    }
+}


### PR DESCRIPTION
Closes #59.

Brings parity with `sdk-swift`: a Kotlin/JVM core state machine + Jetpack Compose UI + drop-in `PlaidifyLinkActivity` with WebView fallback for institutions outside the native registry.

## Modules
- **`sdk-android/core/`** — Pure Kotlin/JVM (Java 17). No Android deps so it's unit-testable on the JVM.
  - `PlaidifyLinkClient` — suspend REST client over a pluggable `PlaidifyLinkHttpClient` (status / search / encryption key / connect / MFA submit).
  - `PlaidifyLinkUrlBuilder`, `PlaidifyLinkConnectFlow`, `PlaidifyLinkInstitutionRegistry` mirror the Swift counterparts in #58.
- **`sdk-android/ui/`** — Jetpack Compose `Picker`, `Credentials`, `Mfa`, `Progress`, `Error` screens + `PlaidifyLinkActivity`. Source-only; host apps wire AGP + Compose + OkHttp themselves (see README).

## Tests
`gradle :core:test` (Gradle 9.4.1, Kotlin 1.9.25, JUnit 5.10.2, Java 17): **13/13 pass**.
- `PlaidifyLinkClientTest` (6) — URL escaping, JSON decode, typed `error_code`, connect-body shape.
- `PlaidifyLinkConnectFlowTest` (7) — happy path / MFA / error / unsupported auth-style fallback / site-not-in-registry fallback / reset / unknown-auth-style fallback.

## Notes
- AGP/Compose runtime verification on emulator is left to a host app + dedicated Android CI lane; this PR validates the JVM core and ships the Compose sources + integration docs.
- All native events match the WebView bridge contract so existing event consumers don't change.
