### PR TITLE
feat(refresh): schedule presets, PATCH endpoint, create_link binding, REFRESH_FAILED webhook (#23)

### DIFF
--- a/alembic/versions/m3n4o5p6q7r8_add_schedule_format.py
+++ b/alembic/versions/m3n4o5p6q7r8_add_schedule_format.py
@@ -1,0 +1,31 @@
+"""Add schedule_format to scheduled_refresh_jobs.
+
+Revision ID: m3n4o5p6q7r8
+Revises: l2m3n4o5p6q7
+Create Date: 2026-04-24 12:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "m3n4o5p6q7r8"
+down_revision = "l2m3n4o5p6q7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scheduled_refresh_jobs",
+        sa.Column(
+            "schedule_format",
+            sa.String(),
+            nullable=False,
+            server_default="interval",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("scheduled_refresh_jobs", "schedule_format")

--- a/docs/SCHEDULED_REFRESH.md
+++ b/docs/SCHEDULED_REFRESH.md
@@ -1,0 +1,132 @@
+# Scheduled Refresh
+
+Plaidify periodically re-runs `connect_to_site` for stored access tokens so
+hosted data stays fresh without the integrator polling. This document covers
+the public API surface, schedule formats, abuse controls, and the standardized
+webhook contract.
+
+## Schedule formats
+
+The scheduler accepts four formats:
+
+| `schedule_format` | `interval_seconds` (effective) | Notes |
+|---|---|---|
+| `interval` (default) | caller-supplied | Minimum 300 s (5 min) at the API. |
+| `hourly`             | 3 600                           | Preset; ignores any supplied interval. |
+| `daily`              | 86 400                          | Preset. |
+| `weekly`             | 604 800                         | Preset. |
+
+Future formats (e.g. `cron`) can be added without breaking the schema —
+clients should treat unknown values as opaque strings.
+
+## Endpoints
+
+### `POST /refresh/schedule`
+
+Body:
+
+```json
+{
+  "access_token": "acc-…",
+  "schedule_format": "hourly"
+}
+```
+
+or
+
+```json
+{
+  "access_token": "acc-…",
+  "schedule_format": "interval",
+  "interval_seconds": 1800
+}
+```
+
+### `PATCH /refresh/schedule/{access_token}`
+
+Update any combination of `interval_seconds`, `schedule_format`, `enabled`.
+Returns the post-update schedule. Re-enabling resets `consecutive_failures`.
+
+### `DELETE /refresh/schedule/{access_token}`
+
+Removes the schedule.
+
+### `GET /refresh/jobs`
+
+Lists active schedules for the authenticated user (admin scope today).
+
+### `POST /create_link` — deferred binding
+
+`/create_link` accepts an optional `refresh_schedule` body field that is
+stashed against the link token and applied once `/submit_credentials`
+mints an access token. This lets integrators express "create + schedule"
+in one round trip.
+
+```json
+{
+  "scopes": ["balance"],
+  "refresh_schedule": { "schedule_format": "daily" }
+}
+```
+
+The directive is validated at `/create_link` time (bad formats / sub-minimum
+intervals return `400`), then consumed exactly once at `/submit_credentials`.
+
+## Abuse controls
+
+- `POST /refresh/schedule` and `PATCH /refresh/schedule/{access_token}` are
+  rate-limited to **30 requests / minute / client** via `slowapi`.
+- A user may have at most **`MAX_SCHEDULES_PER_USER` (default 50)**
+  active schedules. Attempting to register a 51st returns `429`.
+- Per-job exponential backoff doubles the effective interval on each
+  consecutive failure, capped at 24 h. After
+  `_MAX_CONSECUTIVE_FAILURES` (10), the job is auto-disabled and a
+  `REFRESH_FAILED` webhook is dispatched.
+
+## Webhook contract (`event_version: 2`)
+
+Both refresh-triggered webhook events share a base envelope:
+
+```json
+{
+  "event_version": 2,
+  "access_token_prefix": "acc-abc1234...",
+  "timestamp": "2026-04-24T12:00:00+00:00",
+  "event": "DATA_REFRESHED" | "REFRESH_FAILED",
+  "success": true | false
+}
+```
+
+### `DATA_REFRESHED`
+
+```json
+{
+  "event": "DATA_REFRESHED",
+  "event_version": 2,
+  "access_token_prefix": "acc-abc1234...",
+  "timestamp": "2026-04-24T12:00:00+00:00",
+  "success": true,
+  "fields_updated": ["balance", "transactions"]
+}
+```
+
+### `REFRESH_FAILED`
+
+Fired exactly once when a job is auto-disabled after
+`_MAX_CONSECUTIVE_FAILURES` (10) consecutive failures.
+
+```json
+{
+  "event": "REFRESH_FAILED",
+  "event_version": 2,
+  "access_token_prefix": "acc-abc1234...",
+  "timestamp": "2026-04-24T12:00:00+00:00",
+  "success": false,
+  "error": "<sanitized exception message>",
+  "consecutive_failures": 10
+}
+```
+
+Integrators should re-enable a disabled schedule via
+`PATCH /refresh/schedule/{access_token}` with `{"enabled": true}` after
+addressing the underlying issue (typically expired credentials).

--- a/src/database.py
+++ b/src/database.py
@@ -662,6 +662,7 @@ class ScheduledRefreshJob(Base):
     access_token = Column(String, ForeignKey("access_tokens.token", ondelete="CASCADE"), primary_key=True)
     user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
     interval_seconds = Column(Integer, nullable=False, default=3600)
+    schedule_format = Column(String, nullable=False, default="interval")
     enabled = Column(Boolean, default=True, nullable=False)
     last_refreshed = Column(DateTime, nullable=True)
     last_error = Column(Text, nullable=True)

--- a/src/routers/links.py
+++ b/src/routers/links.py
@@ -62,11 +62,14 @@ async def create_link(
     or scope strings (e.g. ``["balance", "transactions"]``) that will be
     enforced on data retrieval. If omitted, all fields are allowed.
     """
-    # Parse optional scopes from JSON body
+    # Parse optional scopes / refresh_schedule from JSON body
     scopes = None
+    refresh_schedule = None
     try:
         body = await request.json()
-        scopes = body.get("scopes") if body else None
+        if body:
+            scopes = body.get("scopes")
+            refresh_schedule = body.get("refresh_schedule")
     except Exception:
         pass  # No body or non-JSON body is fine
 
@@ -86,6 +89,31 @@ async def create_link(
     if effective_scopes is not None:
         session_store.set_link_scopes(link_token, json_mod.dumps(effective_scopes))
         result["scopes"] = effective_scopes
+    if refresh_schedule is not None:
+        # Validate the directive eagerly so /create_link rejects bad input
+        # rather than silently failing later in /submit_credentials.
+        from src.scheduled_refresh import resolve_schedule
+
+        if not isinstance(refresh_schedule, dict):
+            raise HTTPException(status_code=400, detail="refresh_schedule must be an object.")
+        try:
+            fmt, resolved_interval = resolve_schedule(
+                schedule_format=refresh_schedule.get("schedule_format")
+                or refresh_schedule.get("format"),
+                interval_seconds=refresh_schedule.get("interval_seconds", 3600),
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+        from src.scheduled_refresh import MIN_INTERVAL_SECONDS
+
+        if resolved_interval < MIN_INTERVAL_SECONDS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Minimum interval is {MIN_INTERVAL_SECONDS} seconds (5 minutes).",
+            )
+        directive = {"schedule_format": fmt, "interval_seconds": resolved_interval}
+        session_store.set_link_refresh_schedule(link_token, json_mod.dumps(directive))
+        result["refresh_schedule"] = directive
     return result
 
 
@@ -158,6 +186,31 @@ async def submit_credentials(
     result = {"access_token": access_token}
     if token_scopes:
         result["scopes"] = json_mod.loads(token_scopes)
+
+    # If /create_link attached a refresh_schedule directive, register it now
+    # that we have an access_token. Failures here are non-fatal; the caller
+    # can always re-register via POST /refresh/schedule.
+    deferred = session_store.pop_link_refresh_schedule(link_token)
+    if deferred:
+        try:
+            from src.routers.refresh import _get_refresh_scheduler
+
+            directive = json_mod.loads(deferred)
+            scheduler = _get_refresh_scheduler()
+            if not scheduler.running:
+                scheduler.start()
+            scheduler.schedule(
+                access_token,
+                user.id,
+                interval_seconds=directive.get("interval_seconds"),
+                schedule_format=directive.get("schedule_format"),
+            )
+            result["refresh_schedule"] = {
+                "interval_seconds": directive.get("interval_seconds"),
+                "schedule_format": directive.get("schedule_format"),
+            }
+        except Exception:
+            logger.exception("Failed to apply deferred refresh_schedule for %s", link_token)
     return result
 
 

--- a/src/routers/refresh.py
+++ b/src/routers/refresh.py
@@ -20,12 +20,21 @@ from src.database import (
     decrypt_credential_for_user,
     get_db,
 )
-from src.dependencies import get_current_user
-from src.scheduled_refresh import RefreshScheduler
+from src.dependencies import get_current_user, limiter
+from src.scheduled_refresh import (
+    MIN_INTERVAL_SECONDS,
+    RefreshScheduler,
+    SCHEDULE_FORMATS,
+    SCHEDULE_FORMAT_INTERVAL,
+    resolve_schedule,
+)
 
 settings = get_settings()
 
 router = APIRouter(prefix="/refresh", tags=["refresh"])
+
+# Abuse controls: cap how many active schedules a single user may register.
+MAX_SCHEDULES_PER_USER = 50
 
 _refresh_scheduler: Optional[RefreshScheduler] = None
 
@@ -69,22 +78,48 @@ def _get_refresh_scheduler() -> RefreshScheduler:
                 db.close()
 
         async def _on_refresh_webhook(access_token: str, user_id: int, data: Dict) -> None:
-            """Fire DATA_REFRESHED webhooks after a successful refresh."""
+            """Fire DATA_REFRESHED / REFRESH_FAILED webhooks after a refresh.
+
+            Standardized payload contract (event_version=2):
+              - event: "DATA_REFRESHED" | "REFRESH_FAILED"
+              - event_version: 2
+              - access_token_prefix: first 12 chars of token + "..."
+              - timestamp: ISO 8601 UTC
+              - success: bool
+              - fields_updated: list[str]   (DATA_REFRESHED only)
+              - error: str                  (REFRESH_FAILED only)
+              - consecutive_failures: int   (REFRESH_FAILED only)
+            """
             from src.routers.webhooks import _deliver_webhook
 
             db = next(get_db())
             try:
                 token_record = db.query(AccessToken).filter_by(token=access_token, user_id=user_id).first()
-                if token_record:
-                    webhooks = db.query(Webhook).filter_by(link_token=token_record.link_token).all()
+                if not token_record:
+                    return
+                webhooks = db.query(Webhook).filter_by(link_token=token_record.link_token).all()
+                base = {
+                    "event_version": 2,
+                    "access_token_prefix": access_token[:12] + "...",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                }
+                if isinstance(data, dict) and data.get("__refresh_failed__"):
                     payload = {
+                        **base,
+                        "event": "REFRESH_FAILED",
+                        "success": False,
+                        "error": str(data.get("error", "unknown")),
+                        "consecutive_failures": int(data.get("consecutive_failures", 0)),
+                    }
+                else:
+                    payload = {
+                        **base,
                         "event": "DATA_REFRESHED",
-                        "access_token_prefix": access_token[:12] + "...",
-                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "success": True,
                         "fields_updated": (list(data.keys()) if isinstance(data, dict) else []),
                     }
-                    for wh in webhooks:
-                        asyncio.create_task(_deliver_webhook(wh.id, wh.url, wh.secret, payload))
+                for wh in webhooks:
+                    asyncio.create_task(_deliver_webhook(wh.id, wh.url, wh.secret, payload))
             finally:
                 db.close()
 
@@ -97,6 +132,7 @@ def _get_refresh_scheduler() -> RefreshScheduler:
 
 
 @router.post("/schedule")
+@limiter.limit("30/minute")
 async def schedule_refresh(
     request: Request,
     user: User = Depends(get_current_user),
@@ -105,19 +141,31 @@ async def schedule_refresh(
     """Schedule periodic data refresh for an access token.
 
     Body:
-        access_token: The access token to refresh.
-        interval_seconds: How often to refresh (minimum 300 = 5 minutes).
+        access_token (str, required)
+        schedule_format (str, optional): one of
+            ``interval`` (default), ``hourly``, ``daily``, ``weekly``.
+        interval_seconds (int, optional): required when format is ``interval``.
+            Minimum 300 (5 minutes).
     """
     body = await request.json()
     access_token = body.get("access_token")
     interval = body.get("interval_seconds", 3600)
+    schedule_format = body.get("schedule_format") or body.get("format")
 
     if not access_token:
         raise HTTPException(status_code=400, detail="access_token is required.")
-    if interval < 300:
+
+    try:
+        fmt, resolved_interval = resolve_schedule(
+            schedule_format=schedule_format,
+            interval_seconds=interval,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if resolved_interval < MIN_INTERVAL_SECONDS:
         raise HTTPException(
             status_code=400,
-            detail="Minimum interval is 300 seconds (5 minutes).",
+            detail=f"Minimum interval is {MIN_INTERVAL_SECONDS} seconds (5 minutes).",
         )
 
     # Verify the token belongs to this user
@@ -126,9 +174,25 @@ async def schedule_refresh(
         raise HTTPException(status_code=404, detail="Access token not found.")
 
     scheduler = _get_refresh_scheduler()
+    # Abuse control: cap active schedules per user.
+    if access_token not in scheduler.list_jobs():
+        active = len(scheduler.jobs_for_user(user.id))
+        if active >= MAX_SCHEDULES_PER_USER:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    f"Refresh schedule quota exceeded "
+                    f"(max {MAX_SCHEDULES_PER_USER} active schedules per user)."
+                ),
+            )
     if not scheduler.running:
         scheduler.start()
-    scheduler.schedule(access_token, user.id, interval)
+    scheduler.schedule(
+        access_token,
+        user.id,
+        interval_seconds=resolved_interval,
+        schedule_format=fmt,
+    )
 
     record_audit_event(
         db,
@@ -136,12 +200,78 @@ async def schedule_refresh(
         "schedule",
         user_id=user.id,
         resource=access_token[:12],
-        metadata={"interval_seconds": interval},
+        metadata={"interval_seconds": resolved_interval, "schedule_format": fmt},
     )
     return {
         "status": "scheduled",
         "access_token": access_token[:12] + "...",
-        "interval_seconds": interval,
+        "interval_seconds": resolved_interval,
+        "schedule_format": fmt,
+    }
+
+
+@router.patch("/schedule/{access_token}")
+@limiter.limit("30/minute")
+async def update_schedule(
+    access_token: str,
+    request: Request,
+    user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update an existing refresh schedule.
+
+    Body fields are all optional; any combination of ``interval_seconds``,
+    ``schedule_format``, and ``enabled`` may be supplied.
+    """
+    body = await request.json()
+    interval = body.get("interval_seconds")
+    schedule_format = body.get("schedule_format") or body.get("format")
+    enabled = body.get("enabled")
+
+    token_record = db.query(AccessToken).filter_by(token=access_token, user_id=user.id).first()
+    if not token_record:
+        raise HTTPException(status_code=404, detail="Access token not found.")
+
+    scheduler = _get_refresh_scheduler()
+    if access_token not in scheduler.list_jobs():
+        raise HTTPException(status_code=404, detail="No refresh schedule found for this token.")
+
+    try:
+        job = scheduler.update(
+            access_token,
+            interval_seconds=interval,
+            schedule_format=schedule_format,
+            enabled=enabled,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    if job is not None and job.interval_seconds < MIN_INTERVAL_SECONDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Minimum interval is {MIN_INTERVAL_SECONDS} seconds (5 minutes).",
+        )
+
+    if job is None:
+        raise HTTPException(status_code=404, detail="No refresh schedule found for this token.")
+
+    record_audit_event(
+        db,
+        "refresh",
+        "update",
+        user_id=user.id,
+        resource=access_token[:12],
+        metadata={
+            "interval_seconds": job.interval_seconds,
+            "schedule_format": job.schedule_format,
+            "enabled": job.enabled,
+        },
+    )
+    return {
+        "status": "updated",
+        "access_token": access_token[:12] + "...",
+        "interval_seconds": job.interval_seconds,
+        "schedule_format": job.schedule_format,
+        "enabled": job.enabled,
     }
 
 

--- a/src/scheduled_refresh.py
+++ b/src/scheduled_refresh.py
@@ -29,6 +29,52 @@ from typing import Any, Callable, Dict, Optional
 logger = logging.getLogger("plaidify.scheduler")
 
 
+# ── Schedule formats ─────────────────────────────────────────────────────────
+
+SCHEDULE_FORMAT_INTERVAL = "interval"
+SCHEDULE_FORMAT_HOURLY = "hourly"
+SCHEDULE_FORMAT_DAILY = "daily"
+SCHEDULE_FORMAT_WEEKLY = "weekly"
+
+SCHEDULE_FORMATS = (
+    SCHEDULE_FORMAT_INTERVAL,
+    SCHEDULE_FORMAT_HOURLY,
+    SCHEDULE_FORMAT_DAILY,
+    SCHEDULE_FORMAT_WEEKLY,
+)
+
+_PRESET_INTERVAL_SECONDS = {
+    SCHEDULE_FORMAT_HOURLY: 3600,
+    SCHEDULE_FORMAT_DAILY: 86400,
+    SCHEDULE_FORMAT_WEEKLY: 604800,
+}
+
+MIN_INTERVAL_SECONDS = 300  # 5 minutes
+
+
+def resolve_schedule(
+    schedule_format: Optional[str] = None,
+    interval_seconds: Optional[int] = None,
+) -> tuple[str, int]:
+    """Normalize a (format, interval) pair.
+
+    Returns ``(schedule_format, interval_seconds)`` where the interval reflects
+    the chosen preset. Raises ``ValueError`` for unknown formats or sub-minimum
+    intervals.
+    """
+    fmt = (schedule_format or SCHEDULE_FORMAT_INTERVAL).lower()
+    if fmt not in SCHEDULE_FORMATS:
+        raise ValueError(
+            f"Unknown schedule format '{schedule_format}'. "
+            f"Supported: {', '.join(SCHEDULE_FORMATS)}."
+        )
+    if fmt in _PRESET_INTERVAL_SECONDS:
+        return fmt, _PRESET_INTERVAL_SECONDS[fmt]
+    if interval_seconds is None:
+        raise ValueError("interval_seconds is required when schedule_format is 'interval'.")
+    return SCHEDULE_FORMAT_INTERVAL, int(interval_seconds)
+
+
 @dataclass
 class RefreshJob:
     """A single scheduled refresh job."""
@@ -36,6 +82,7 @@ class RefreshJob:
     access_token: str
     user_id: int
     interval_seconds: int
+    schedule_format: str = SCHEDULE_FORMAT_INTERVAL
     last_refreshed: Optional[datetime] = None
     last_error: Optional[str] = None
     consecutive_failures: int = 0
@@ -85,33 +132,82 @@ class RefreshScheduler:
         access_token: str,
         user_id: int,
         interval_seconds: Optional[int] = None,
+        schedule_format: Optional[str] = None,
     ) -> RefreshJob:
         """Register or update a refresh job for an access token.
 
         Args:
             access_token: The access token to periodically refresh.
             user_id: Owner of the token (used for auth in fetch).
-            interval_seconds: Override the default interval for this job.
+            interval_seconds: Override the default interval for this job (used
+                when ``schedule_format`` is ``'interval'`` or omitted).
+            schedule_format: One of ``interval``/``hourly``/``daily``/``weekly``.
+                Presets ignore ``interval_seconds`` and use canonical values.
 
         Returns:
             The created or updated RefreshJob.
         """
+        fmt, resolved_interval = resolve_schedule(
+            schedule_format=schedule_format,
+            interval_seconds=interval_seconds or self._default_interval,
+        )
         if access_token in self._jobs:
             job = self._jobs[access_token]
-            job.interval_seconds = interval_seconds or self._default_interval
+            job.interval_seconds = resolved_interval
+            job.schedule_format = fmt
             job.enabled = True
             job.consecutive_failures = 0
-            logger.info("Updated refresh job for %s (interval=%ds)", access_token[:12], job.interval_seconds)
+            logger.info(
+                "Updated refresh job for %s (format=%s, interval=%ds)",
+                access_token[:12], fmt, job.interval_seconds,
+            )
         else:
             job = RefreshJob(
                 access_token=access_token,
                 user_id=user_id,
-                interval_seconds=interval_seconds or self._default_interval,
+                interval_seconds=resolved_interval,
+                schedule_format=fmt,
             )
             self._jobs[access_token] = job
-            logger.info("Scheduled refresh for %s (interval=%ds)", access_token[:12], job.interval_seconds)
+            logger.info(
+                "Scheduled refresh for %s (format=%s, interval=%ds)",
+                access_token[:12], fmt, job.interval_seconds,
+            )
         self._persist_job(job)
         return job
+
+    def update(
+        self,
+        access_token: str,
+        interval_seconds: Optional[int] = None,
+        schedule_format: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ) -> Optional[RefreshJob]:
+        """Update an existing refresh job in place.
+
+        Returns the updated job, or ``None`` if no job exists for the token.
+        Raises ``ValueError`` for invalid formats / intervals.
+        """
+        job = self._jobs.get(access_token)
+        if job is None:
+            return None
+        if schedule_format is not None or interval_seconds is not None:
+            fmt, resolved_interval = resolve_schedule(
+                schedule_format=schedule_format or job.schedule_format,
+                interval_seconds=interval_seconds or job.interval_seconds,
+            )
+            job.schedule_format = fmt
+            job.interval_seconds = resolved_interval
+        if enabled is not None:
+            job.enabled = bool(enabled)
+            if enabled:
+                job.consecutive_failures = 0
+        self._persist_job(job)
+        return job
+
+    def jobs_for_user(self, user_id: int) -> list[RefreshJob]:
+        """Return all scheduled jobs owned by ``user_id``."""
+        return [job for job in self._jobs.values() if job.user_id == user_id]
 
     def unschedule(self, access_token: str) -> bool:
         """Remove a refresh job.
@@ -132,6 +228,7 @@ class RefreshScheduler:
             token: {
                 "user_id": job.user_id,
                 "interval_seconds": job.interval_seconds,
+                "schedule_format": job.schedule_format,
                 "enabled": job.enabled,
                 "last_refreshed": job.last_refreshed.isoformat() if job.last_refreshed else None,
                 "last_error": job.last_error,
@@ -240,6 +337,18 @@ class RefreshScheduler:
                         token_short,
                         job.consecutive_failures,
                     )
+                    if self._webhook:
+                        try:
+                            await self._webhook(
+                                job.access_token,
+                                job.user_id,
+                                {"__refresh_failed__": True, "error": str(exc),
+                                 "consecutive_failures": job.consecutive_failures},
+                            )
+                        except Exception:
+                            logger.exception(
+                                "REFRESH_FAILED webhook callback failed for %s", token_short,
+                            )
             finally:
                 self._persist_job(job)
 
@@ -258,6 +367,7 @@ class RefreshScheduler:
                         access_token=row.access_token,
                         user_id=row.user_id,
                         interval_seconds=row.interval_seconds,
+                        schedule_format=getattr(row, "schedule_format", None) or SCHEDULE_FORMAT_INTERVAL,
                         last_refreshed=row.last_refreshed,
                         last_error=row.last_error,
                         consecutive_failures=row.consecutive_failures,
@@ -281,12 +391,14 @@ class RefreshScheduler:
                 row = db.query(ScheduledRefreshJob).filter_by(access_token=job.access_token).first()
                 if row:
                     row.interval_seconds = job.interval_seconds
+                    if hasattr(row, "schedule_format"):
+                        row.schedule_format = job.schedule_format
                     row.enabled = job.enabled
                     row.last_refreshed = job.last_refreshed
                     row.last_error = job.last_error
                     row.consecutive_failures = job.consecutive_failures
                 else:
-                    row = ScheduledRefreshJob(
+                    kwargs = dict(
                         access_token=job.access_token,
                         user_id=job.user_id,
                         interval_seconds=job.interval_seconds,
@@ -295,6 +407,9 @@ class RefreshScheduler:
                         last_error=job.last_error,
                         consecutive_failures=job.consecutive_failures,
                     )
+                    if hasattr(ScheduledRefreshJob, "schedule_format"):
+                        kwargs["schedule_format"] = job.schedule_format
+                    row = ScheduledRefreshJob(**kwargs)
                     db.add(row)
                 db.commit()
             finally:

--- a/src/session_store.py
+++ b/src/session_store.py
@@ -216,6 +216,43 @@ def pop_link_scopes(link_token: str) -> Optional[str]:
         return _mem_link_scopes.pop(link_token, None)
 
 
+# ── Refresh schedule (deferred) ─────────────────────────────────────────────
+# Stored at /create_link, consumed at /submit_credentials so a refresh job can
+# be registered as soon as the access_token is minted.
+
+_mem_link_refresh_schedules: Dict[str, str] = {}
+
+
+def set_link_refresh_schedule(link_token: str, schedule_json: str) -> None:
+    """Store a deferred refresh-schedule directive keyed on link_token."""
+    r = _redis()
+    if r:
+        r.set(
+            f"plaidify:link_refresh:{link_token}",
+            schedule_json,
+            ex=LINK_SCOPE_TTL,
+        )
+    else:
+        if len(_mem_link_refresh_schedules) > _MAX_MEM_LINK_SCOPES:
+            excess = len(_mem_link_refresh_schedules) - _MAX_MEM_LINK_SCOPES
+            for key in list(_mem_link_refresh_schedules)[:excess]:
+                del _mem_link_refresh_schedules[key]
+        _mem_link_refresh_schedules[link_token] = schedule_json
+
+
+def pop_link_refresh_schedule(link_token: str) -> Optional[str]:
+    """Get and remove the deferred refresh-schedule for a link token."""
+    r = _redis()
+    if r:
+        key = f"plaidify:link_refresh:{link_token}"
+        val = r.get(key)
+        if val:
+            r.delete(key)
+        return val
+    else:
+        return _mem_link_refresh_schedules.pop(link_token, None)
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # Link Launch Bootstrap Store
 # ══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_scheduled_refresh_followups.py
+++ b/tests/test_scheduled_refresh_followups.py
@@ -1,0 +1,163 @@
+"""Tests for scheduled-refresh follow-ups (#23):
+
+- Schedule presets (hourly / daily / weekly)
+- PATCH /refresh/schedule/{access_token}
+- refresh_schedule passthrough on /create_link
+- REFRESH_FAILED webhook event
+- Per-user max-schedule abuse cap
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.scheduled_refresh import (
+    MIN_INTERVAL_SECONDS,
+    RefreshScheduler,
+    SCHEDULE_FORMAT_DAILY,
+    SCHEDULE_FORMAT_HOURLY,
+    SCHEDULE_FORMAT_INTERVAL,
+    SCHEDULE_FORMAT_WEEKLY,
+    resolve_schedule,
+)
+
+
+class TestResolveSchedule:
+    def test_default_format_is_interval(self):
+        fmt, secs = resolve_schedule(interval_seconds=600)
+        assert fmt == SCHEDULE_FORMAT_INTERVAL
+        assert secs == 600
+
+    @pytest.mark.parametrize(
+        "preset,expected",
+        [
+            (SCHEDULE_FORMAT_HOURLY, 3600),
+            (SCHEDULE_FORMAT_DAILY, 86400),
+            (SCHEDULE_FORMAT_WEEKLY, 604800),
+        ],
+    )
+    def test_presets_resolve_to_canonical_intervals(self, preset, expected):
+        fmt, secs = resolve_schedule(schedule_format=preset)
+        assert fmt == preset
+        assert secs == expected
+
+    def test_unknown_format_raises(self):
+        with pytest.raises(ValueError, match="Unknown schedule format"):
+            resolve_schedule(schedule_format="cron")
+
+    def test_interval_format_requires_interval_seconds(self):
+        with pytest.raises(ValueError, match="interval_seconds is required"):
+            resolve_schedule(schedule_format="interval", interval_seconds=None)
+
+    def test_resolve_does_not_enforce_minimum(self):
+        # The 5-minute floor is enforced at the API layer, not the resolver.
+        fmt, secs = resolve_schedule(schedule_format="interval", interval_seconds=10)
+        assert secs == 10
+
+
+class TestSchedulerPresetsAndUpdate:
+    @pytest.fixture
+    def scheduler(self):
+        return RefreshScheduler(
+            fetch_callback=AsyncMock(return_value={"a": 1}),
+            webhook_callback=AsyncMock(),
+            interval_seconds=60,
+        )
+
+    def test_schedule_with_preset_uses_canonical_interval(self, scheduler):
+        job = scheduler.schedule(
+            "acc-1", user_id=7, schedule_format=SCHEDULE_FORMAT_HOURLY,
+        )
+        assert job.schedule_format == SCHEDULE_FORMAT_HOURLY
+        assert job.interval_seconds == 3600
+
+    def test_update_returns_none_for_unknown_token(self, scheduler):
+        assert scheduler.update("nope") is None
+
+    def test_update_changes_interval_only(self, scheduler):
+        scheduler.schedule("acc-1", user_id=7, interval_seconds=600)
+        job = scheduler.update("acc-1", interval_seconds=900)
+        assert job is not None
+        assert job.interval_seconds == 900
+        assert job.schedule_format == SCHEDULE_FORMAT_INTERVAL
+
+    def test_update_switches_to_preset(self, scheduler):
+        scheduler.schedule("acc-1", user_id=7, interval_seconds=600)
+        job = scheduler.update("acc-1", schedule_format=SCHEDULE_FORMAT_DAILY)
+        assert job.schedule_format == SCHEDULE_FORMAT_DAILY
+        assert job.interval_seconds == 86400
+
+    def test_update_can_disable_and_reenable(self, scheduler):
+        scheduler.schedule("acc-1", user_id=7, interval_seconds=600)
+        scheduler.update("acc-1", enabled=False)
+        assert scheduler._jobs["acc-1"].enabled is False
+        job = scheduler.update("acc-1", enabled=True)
+        assert job.enabled is True
+        # Re-enabling should reset the failure counter so backoff resets.
+        assert job.consecutive_failures == 0
+
+    def test_update_rejects_invalid_format(self, scheduler):
+        scheduler.schedule("acc-1", user_id=7, interval_seconds=600)
+        with pytest.raises(ValueError):
+            scheduler.update("acc-1", schedule_format="quarterly")
+
+    def test_jobs_for_user_isolates_owners(self, scheduler):
+        scheduler.schedule("acc-a", user_id=1, interval_seconds=600)
+        scheduler.schedule("acc-b", user_id=1, interval_seconds=600)
+        scheduler.schedule("acc-c", user_id=2, interval_seconds=600)
+        owned = scheduler.jobs_for_user(1)
+        assert {j.access_token for j in owned} == {"acc-a", "acc-b"}
+
+
+class TestRefreshFailedWebhook:
+    def test_max_failures_disables_and_emits_failure_payload(self):
+        webhook = AsyncMock()
+
+        async def _failing_fetch(_token, _uid):
+            raise RuntimeError("boom")
+
+        scheduler = RefreshScheduler(
+            fetch_callback=_failing_fetch,
+            webhook_callback=webhook,
+            interval_seconds=60,
+        )
+        scheduler.schedule("acc-1", user_id=1, interval_seconds=60)
+        job = scheduler._jobs["acc-1"]
+        # Force one-shy-of-max so a single failure triggers the disable path.
+        job.consecutive_failures = scheduler._MAX_CONSECUTIVE_FAILURES - 1
+
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            sem = asyncio.Semaphore(1)
+            loop.run_until_complete(scheduler._execute_job(job, sem))
+        finally:
+            loop.close()
+
+        assert job.enabled is False
+        assert job.consecutive_failures >= scheduler._MAX_CONSECUTIVE_FAILURES
+        assert webhook.await_count == 1
+        kwargs_or_args = webhook.await_args
+        # third positional arg is the data dict
+        data = kwargs_or_args.args[2]
+        assert data.get("__refresh_failed__") is True
+        assert data.get("error") == "boom"
+
+
+class TestApiAbuseControls:
+    def test_per_user_cap_constant_is_exposed(self):
+        from src.routers import refresh as refresh_router
+
+        assert isinstance(refresh_router.MAX_SCHEDULES_PER_USER, int)
+        assert refresh_router.MAX_SCHEDULES_PER_USER >= 1
+
+    def test_jobs_for_user_drives_quota_check(self):
+        scheduler = RefreshScheduler(
+            fetch_callback=AsyncMock(return_value={}),
+            interval_seconds=60,
+        )
+        for i in range(3):
+            scheduler.schedule(f"acc-{i}", user_id=42, interval_seconds=600)
+        assert len(scheduler.jobs_for_user(42)) == 3
+        assert len(scheduler.jobs_for_user(99)) == 0


### PR DESCRIPTION
Closes #23.

Ships every remaining bullet from the issue:

## Schedule formats
- New `schedule_format` field (`interval` | `hourly` | `daily` | `weekly`) on `RefreshJob` and the persisted `ScheduledRefreshJob`.
- `resolve_schedule()` helper normalizes (format, interval) input; presets resolve to canonical 3600 / 86400 / 604800 second intervals.
- Alembic migration `m3n4o5p6q7r8` adds `schedule_format` with server default `'interval'` so existing rows upgrade transparently.

## API
- `POST /refresh/schedule` accepts `schedule_format` (alias `format`).
- **New** `PATCH /refresh/schedule/{access_token}` updates any combination of `interval_seconds` / `schedule_format` / `enabled`. Re-enabling resets the failure counter.
- `POST /create_link` accepts an optional `refresh_schedule` body that is validated eagerly, stashed via `session_store`, and applied at `/submit_credentials` once the access token exists.

## Abuse controls
- `slowapi` `@limiter.limit("30/minute")` on `POST` + `PATCH /refresh/schedule`.
- Per-user cap: `MAX_SCHEDULES_PER_USER = 50` (exceeding returns `429`).

## Webhook contract (`event_version: 2`)
- `DATA_REFRESHED` payload gains `event_version`, `success: true` (additive — existing consumers unaffected).
- **New** `REFRESH_FAILED` event fired exactly once when a job is auto-disabled after 10 consecutive failures, carrying `success: false`, `error`, `consecutive_failures`.

## Tests
- 17 new tests in `tests/test_scheduled_refresh_followups.py` (resolver, presets, update semantics, `jobs_for_user`, `REFRESH_FAILED` dispatch).
- All 24 pre-existing scheduler/refresh tests still pass.
- Smoke (`test_links` + `test_api_smoke` + `test_main` + `test_hosted_link_e2e`) all green: **44 passed**.

## Docs
- New `docs/SCHEDULED_REFRESH.md` covering endpoints, presets, abuse controls, and the standardized webhook contract.
