### PR TITLE
chore(deps): resolve 16 dependency CVEs (starlette 1.x, pyjwt, cryptography, pydantic-settings)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 # ── Core ──────────────────────────────────────────────────────────────────────
-fastapi==0.136.0
-starlette==0.49.1
+fastapi==0.138.0
+starlette==1.3.1
 uvicorn[standard]==0.34.1
 gunicorn==23.0.0
-pydantic==2.13.2
-pydantic-settings==2.13.1
+pydantic==2.13.4
+pydantic-settings==2.14.2
 
 # ── Database ──────────────────────────────────────────────────────────────────
 sqlalchemy==2.0.49
@@ -12,10 +12,10 @@ alembic==1.18.4
 psycopg2-binary==2.9.11
 
 # ── Security ──────────────────────────────────────────────────────────────────
-cryptography==46.0.7
+cryptography==48.0.1
 passlib[bcrypt]==1.7.4
 bcrypt==4.3.0
-PyJWT==2.12.1
+PyJWT==2.13.0
 slowapi==0.1.9
 
 # ── HTTP & Parsing ───────────────────────────────────────────────────────────
@@ -30,7 +30,7 @@ redis==5.2.1
 
 # ── Monitoring ────────────────────────────────────────────────────────────────
 prometheus-client==0.25.0
-prometheus-fastapi-instrumentator==7.0.2
+prometheus-fastapi-instrumentator==8.0.2
 sentry-sdk[fastapi]==2.19.2
 
 # ── Distributed Tracing (optional) ──────────────────────────────────────────


### PR DESCRIPTION
## Why

The CI **Security Audit** (`pip-audit --strict`) flags **16 known CVEs** across four pinned dependencies (newly-disclosed 2026 advisories; affects `main` too). This PR bumps them to patched releases.

## Security bumps
| Package | From | To | Advisories |
|---|---|---|---|
| starlette | 0.49.1 | **1.3.1** | PYSEC-2026-161, CVE-2026-48818/48817/54283/54282 |
| pyjwt | 2.12.1 | 2.13.0 | PYSEC-2026-175…179 |
| cryptography | 46.0.7 | 48.0.1 | GHSA-537c-gmf6-5ccf |
| pydantic-settings | 2.13.1 | 2.14.2 | GHSA-4xgf-cpjx-pc3j |

## Coordinated bumps (required for Starlette 1.x)
- `fastapi` 0.136.0 → **0.138.0** — declares `starlette>=0.46.0` and ships with the 1.x line.
- `pydantic` 2.13.2 → 2.13.4 — pulled by fastapi 0.138.
- `prometheus-fastapi-instrumentator` 7.0.2 → **8.0.2** — 7.x pinned `starlette<1.0.0`.

Minimal set: `sse-starlette`, `slowapi`, and the OpenTelemetry stack already allow Starlette 1.x and stay pinned.

## Validation
- Full test suite **775 passed / 8 skipped** on the upgraded stack.
- `pip-audit --strict -r requirements.txt` → **No known vulnerabilities found**.

Independent of #116 (no file overlap).