### PR TITLE
chore(prod): observability + security + ops hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,14 @@ POSTGRES_PASSWORD=
 # DEBUG=false
 # ENFORCE_HTTPS=false      # Set true in production (behind TLS proxy)
 
+# ── Registration & Bootstrap ─────────────────────────────────────────────────
+# Disable public self-registration in production and provision the first
+# account via the bootstrap settings (created on startup, idempotent).
+# REGISTRATION_ENABLED=true
+# BOOTSTRAP_USER_USERNAME=admin
+# BOOTSTRAP_USER_EMAIL=admin@example.com
+# BOOTSTRAP_USER_PASSWORD=        # supply via secret store, not source control
+
 # ── Logging ──────────────────────────────────────────────────────────────────
 # LOG_LEVEL=INFO
 # LOG_FORMAT=json   # 'json' for production, 'text' for development
@@ -79,6 +87,7 @@ POSTGRES_PASSWORD=
 # RATE_LIMIT_ENABLED=true
 # RATE_LIMIT_AUTH=5/minute
 # RATE_LIMIT_CONNECT=10/minute
+# RATE_LIMIT_MFA=5/minute      # Per-IP cap on POST /mfa/submit (brute-force guard)
 # RATE_LIMIT_DEFAULT=60/minute
 # HEALTH_CHECK_TOKEN=
 

--- a/src/app.py
+++ b/src/app.py
@@ -107,6 +107,50 @@ def _validate_runtime_configuration() -> None:
 
     redis_client.ping()
 
+    if settings.registration_enabled:
+        logger.warning(
+            "Public self-registration is ENABLED in production. Set REGISTRATION_ENABLED=false "
+            "and provision accounts via BOOTSTRAP_USER_* to reduce abuse surface."
+        )
+
+
+def _bootstrap_user() -> None:
+    """Create the configured bootstrap user if it doesn't already exist.
+
+    Lets operators provision the first account in production without enabling
+    open registration or manipulating the database directly. Idempotent: a
+    no-op when the user already exists or the bootstrap settings are unset.
+    """
+    username = settings.bootstrap_user_username
+    email = settings.bootstrap_user_email
+    password = settings.bootstrap_user_password
+    if not (username and email and password):
+        return
+
+    from src.database import User, create_user_dek
+    from src.dependencies import get_password_hash
+
+    db = next(get_db())
+    try:
+        existing = db.query(User).filter((User.username == username) | (User.email == email)).first()
+        if existing:
+            logger.info("Bootstrap user already present; skipping creation")
+            return
+        db.add(
+            User(
+                username=username,
+                email=email,
+                hashed_password=get_password_hash(password),
+                encrypted_dek=create_user_dek(),
+            )
+        )
+        db.commit()
+        logger.info("Bootstrap user created", extra={"extra_data": {"username": username}})
+    except Exception as exc:  # pragma: no cover - bootstrap must not block startup
+        logger.error(f"Bootstrap user creation failed: {exc}")
+    finally:
+        db.close()
+
 
 async def _cleanup_expired_tokens() -> None:
     """Periodically purge expired and revoked refresh tokens."""
@@ -209,6 +253,7 @@ async def lifespan(app: FastAPI):
     _validate_runtime_configuration()
     _initialize_sentry()
     init_db()
+    _bootstrap_user()
 
     logger.info("Browser engine ready (Playwright, lazy-start)")
 
@@ -264,30 +309,17 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 
 try:
-    from prometheus_client import Counter, Gauge
     from prometheus_fastapi_instrumentator import Instrumentator
 
     Instrumentator().instrument(app).expose(app, endpoint="/metrics")
-    browser_pool_active = Gauge(
-        "plaidify_browser_pool_active_contexts",
-        "Number of active browser contexts in the pool",
-    )
-    extraction_total = Counter(
-        "plaidify_blueprint_extractions_total",
-        "Total blueprint data extractions",
-        ["site", "status"],
-    )
-    mfa_challenges_total = Counter(
-        "plaidify_mfa_challenges_total",
-        "Total MFA challenges encountered",
-        ["mfa_type"],
-    )
+    # Importing the metrics module registers the custom collectors (browser
+    # pool gauge, extraction + MFA counters) so they appear at /metrics. The
+    # engine and browser pool record into them via src.metrics recorders.
+    import src.metrics  # noqa: F401
+
     logger.info("Prometheus metrics enabled at /metrics")
 except ImportError:
     logger.warning("prometheus-fastapi-instrumentator not installed, /metrics endpoint disabled")
-    browser_pool_active = None
-    extraction_total = None
-    mfa_challenges_total = None
 
 
 _cors_origins = [o.strip() for o in settings.cors_origins.split(",") if o.strip()]

--- a/src/config.py
+++ b/src/config.py
@@ -85,6 +85,28 @@ class Settings(BaseSettings):
         description="JWT refresh token expiry in minutes.",
     )
 
+    # ── Registration & Bootstrap ──────────────────────────────
+    registration_enabled: bool = Field(
+        default=True,
+        description=(
+            "Allow public self-registration via POST /auth/register. "
+            "Recommended to disable in production and provision accounts via the "
+            "bootstrap settings below."
+        ),
+    )
+    bootstrap_user_username: Optional[str] = Field(
+        default=None,
+        description="If set with email + password, create this user on startup (idempotent).",
+    )
+    bootstrap_user_email: Optional[str] = Field(
+        default=None,
+        description="Email for the bootstrap user. Required alongside the username/password.",
+    )
+    bootstrap_user_password: Optional[str] = Field(
+        default=None,
+        description="Password for the bootstrap user. Provide via secret store / env, not source control.",
+    )
+
     # ── Server ────────────────────────────────────────────────
     app_name: str = Field(default="Plaidify", description="Application name.")
     app_version: str = Field(default="0.3.0b1", description="Application version.")
@@ -159,6 +181,10 @@ class Settings(BaseSettings):
     rate_limit_connect: str = Field(
         default="10/minute",
         description="Rate limit for /connect endpoint. Format: 'N/period'.",
+    )
+    rate_limit_mfa: str = Field(
+        default="5/minute",
+        description="Rate limit for POST /mfa/submit to deter MFA code brute-force. Format: 'N/period'.",
     )
     rate_limit_default: str = Field(
         default="60/minute",

--- a/src/core/browser_pool.py
+++ b/src/core/browser_pool.py
@@ -28,6 +28,7 @@ from playwright.async_api import (
     async_playwright,
 )
 
+from src import metrics
 from src.config import get_settings
 from src.core.read_only_policy import ExecutionPhase, ReadOnlyExecutionPolicy
 from src.logging_config import get_logger
@@ -267,6 +268,7 @@ class BrowserPool:
                 "Context acquired",
                 extra={"extra_data": {"session_id": session_id, "pool_size": len(self._contexts)}},
             )
+            metrics.set_browser_pool_active(len(self._contexts))
 
             return pooled
 
@@ -295,6 +297,7 @@ class BrowserPool:
             "Context released",
             extra={"extra_data": {"session_id": session_id, "pool_size": len(self._contexts)}},
         )
+        metrics.set_browser_pool_active(len(self._contexts))
 
     @property
     def active_count(self) -> int:

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Type, Union
 from urllib.parse import urlparse
 
+from src import metrics
 from src.config import get_settings
 from src.core.blueprint import (
     BlueprintV2,
@@ -682,6 +683,7 @@ async def _execute_blueprint(
                 for item in pooled.downloads
             ]
 
+        metrics.record_extraction(site, "success")
         return {
             "status": "connected",
             "data": extracted_data,
@@ -700,6 +702,7 @@ async def _execute_blueprint(
     except PlaidifyError:
         raise
     except Exception as e:
+        metrics.record_extraction(site, "error")
         logger.error(
             "Unexpected engine error",
             extra={"extra_data": {"site": site, "error": str(e)}},
@@ -753,6 +756,7 @@ async def _handle_mfa(
         "MFA detected",
         extra={"extra_data": {"site": site, "type": mfa_config.type.value}},
     )
+    metrics.record_mfa_challenge(mfa_config.type.value)
 
     mfa_manager = get_mfa_manager()
     metadata: Dict[str, Any] = {"mfa_type": mfa_config.type.value}

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -61,6 +61,20 @@ limiter = Limiter(
 
 # ── Password Hashing ─────────────────────────────────────────────────────────
 
+# passlib 1.7.4 reads ``bcrypt.__about__.__version__`` which bcrypt 4.x removed,
+# producing a spurious "(trapped) error reading bcrypt version" warning on first
+# hash. Shim the attribute so passlib reads the real version (hashing works
+# either way; this only silences the false-alarm log).
+try:
+    import bcrypt as _bcrypt
+
+    if not hasattr(_bcrypt, "__about__"):
+        import types as _types
+
+        _bcrypt.__about__ = _types.SimpleNamespace(__version__=getattr(_bcrypt, "__version__", "unknown"))
+except Exception:  # pragma: no cover - never block over a logging shim
+    pass
+
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto", bcrypt__rounds=12, bcrypt__ident="2b")
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/auth/token")
 

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,0 +1,72 @@
+"""Prometheus metrics — defined centrally.
+
+These metrics live here (not in ``src.app``) so any module can record values
+without importing the FastAPI application, which would create circular imports
+(``app`` imports the routers, which import the engine, which records metrics).
+
+All recorders are best-effort: if ``prometheus_client`` is not installed, or a
+label/registry error occurs, recording is a no-op and never breaks a request
+flow. The HTTP auto-instrumentation (request counts/latencies) is wired
+separately in ``src.app`` via ``prometheus_fastapi_instrumentator``.
+"""
+
+from __future__ import annotations
+
+from src.logging_config import get_logger
+
+logger = get_logger("metrics")
+
+try:
+    from prometheus_client import Counter, Gauge
+
+    PROMETHEUS_AVAILABLE = True
+
+    browser_pool_active = Gauge(
+        "plaidify_browser_pool_active_contexts",
+        "Number of active browser contexts in the pool",
+    )
+    extraction_total = Counter(
+        "plaidify_blueprint_extractions_total",
+        "Total blueprint data extractions",
+        ["site", "status"],
+    )
+    mfa_challenges_total = Counter(
+        "plaidify_mfa_challenges_total",
+        "Total MFA challenges encountered",
+        ["mfa_type"],
+    )
+except ImportError:  # pragma: no cover - prometheus is an optional dependency
+    PROMETHEUS_AVAILABLE = False
+    browser_pool_active = None
+    extraction_total = None
+    mfa_challenges_total = None
+
+
+def record_extraction(site: str, status: str) -> None:
+    """Count one blueprint extraction attempt with its outcome (success/error)."""
+    if extraction_total is None:
+        return
+    try:
+        extraction_total.labels(site=site, status=status).inc()
+    except Exception:  # pragma: no cover - metrics must never break a flow
+        pass
+
+
+def record_mfa_challenge(mfa_type: str) -> None:
+    """Count one MFA challenge encountered, labelled by MFA type."""
+    if mfa_challenges_total is None:
+        return
+    try:
+        mfa_challenges_total.labels(mfa_type=mfa_type or "unknown").inc()
+    except Exception:  # pragma: no cover
+        pass
+
+
+def set_browser_pool_active(count: int) -> None:
+    """Set the gauge of currently-active browser contexts."""
+    if browser_pool_active is None:
+        return
+    try:
+        browser_pool_active.set(count)
+    except Exception:  # pragma: no cover
+        pass

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -41,6 +41,11 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 @limiter.limit("3/minute")
 def register_user(request: Request, body: UserRegisterRequest, db: Session = Depends(get_db)):
     """Register a new user account."""
+    if not settings.registration_enabled:
+        raise HTTPException(
+            status_code=403,
+            detail="Self-registration is disabled. Contact an administrator for access.",
+        )
     existing = db.query(User).filter((User.username == body.username) | (User.email == body.email)).first()
     if existing:
         raise HTTPException(status_code=400, detail="Username or email already registered")

--- a/src/routers/connection.py
+++ b/src/routers/connection.py
@@ -277,12 +277,14 @@ async def disconnect():
 
 
 @router.post("/mfa/submit")
-async def mfa_submit(session_id: str, code: str):
+@limiter.limit(settings.rate_limit_mfa)
+async def mfa_submit(request: Request, session_id: str, code: str):
     """
     Submit an MFA code for a pending session.
 
     After a connection returns status 'mfa_required', the client retrieves
-    the code from the user and submits it here.
+    the code from the user and submits it here. Rate-limited per IP to deter
+    brute-forcing short numeric codes.
     """
     result = await submit_mfa_code(session_id, code)
     return result

--- a/tests/test_prod_hardening.py
+++ b/tests/test_prod_hardening.py
@@ -1,0 +1,134 @@
+"""Tests for production-hardening changes.
+
+Covers: Prometheus metric wiring, /mfa/submit rate limiting, the registration
+enable/disable gate, the env-driven first-user bootstrap, and the bcrypt shim.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from prometheus_client import generate_latest
+
+# ── Prometheus metrics wiring ────────────────────────────────────────────────
+
+
+class TestMetrics:
+    def test_recorders_expose_values(self):
+        from src import metrics
+
+        metrics.record_extraction("metric_site", "success")
+        metrics.record_extraction("metric_site", "error")
+        metrics.record_mfa_challenge("otp_input")
+        metrics.set_browser_pool_active(2)
+
+        out = generate_latest().decode()
+        assert 'plaidify_blueprint_extractions_total{site="metric_site",status="success"}' in out
+        assert 'plaidify_blueprint_extractions_total{site="metric_site",status="error"}' in out
+        assert 'plaidify_mfa_challenges_total{mfa_type="otp_input"}' in out
+        assert "plaidify_browser_pool_active_contexts 2.0" in out
+
+    def test_recorders_never_raise(self):
+        from src import metrics
+
+        # Empty/odd inputs must be safe — metrics must never break a request flow.
+        metrics.record_mfa_challenge("")
+        metrics.record_extraction("s", "weird-status")
+        metrics.set_browser_pool_active(0)
+
+
+# ── /mfa/submit rate limiting ────────────────────────────────────────────────
+
+
+class TestMfaRateLimit:
+    @pytest.fixture(autouse=True)
+    def _enable_limiter(self):
+        from limits.storage.memory import MemoryStorage
+
+        from src.dependencies import limiter
+
+        limiter._limiter.storage = MemoryStorage()
+        limiter.enabled = True
+        yield
+        limiter.enabled = False
+        limiter._limiter.storage = MemoryStorage()
+
+    def test_mfa_submit_is_rate_limited(self, client):
+        # Default limit is 5/minute. A nonexistent session returns 200 with an
+        # error status; the 6th call within the window should be 429.
+        for _ in range(5):
+            r = client.post("/mfa/submit", params={"session_id": "missing", "code": "000000"})
+            assert r.status_code == 200
+        blocked = client.post("/mfa/submit", params={"session_id": "missing", "code": "000000"})
+        assert blocked.status_code == 429
+
+
+# ── Registration gate ────────────────────────────────────────────────────────
+
+
+class TestRegistrationGate:
+    def test_registration_disabled_returns_403(self, client):
+        with patch("src.routers.auth.settings.registration_enabled", False):
+            r = client.post(
+                "/auth/register",
+                json={"username": "gateuser", "email": "gate@plaidify.dev", "password": "TestPass123!"},
+            )
+            assert r.status_code == 403
+
+    def test_registration_enabled_by_default(self, client):
+        r = client.post(
+            "/auth/register",
+            json={"username": "gateuser2", "email": "gate2@plaidify.dev", "password": "TestPass123!"},
+        )
+        assert r.status_code == 200
+
+
+# ── First-user bootstrap ─────────────────────────────────────────────────────
+
+
+class TestBootstrapUser:
+    def test_bootstrap_creates_user_and_is_idempotent(self, client):
+        import src.app as appmod
+        from src.database import get_db
+
+        # Run the bootstrap against the same test-db session the API uses.
+        override = appmod.app.dependency_overrides.get(get_db)
+        assert override is not None
+
+        with (
+            patch.object(appmod.settings, "bootstrap_user_username", "bootuser"),
+            patch.object(appmod.settings, "bootstrap_user_email", "boot@plaidify.dev"),
+            patch.object(appmod.settings, "bootstrap_user_password", "BootPass123!"),
+            patch.object(appmod, "get_db", override),
+        ):
+            appmod._bootstrap_user()
+            appmod._bootstrap_user()  # idempotent: must not raise or duplicate
+
+        # The bootstrapped account can authenticate.
+        r = client.post("/auth/token", data={"username": "bootuser", "password": "BootPass123!"})
+        assert r.status_code == 200
+        assert "access_token" in r.json()
+
+    def test_bootstrap_noop_when_unset(self):
+        import src.app as appmod
+
+        with patch.object(appmod.settings, "bootstrap_user_username", None):
+            appmod._bootstrap_user()  # no-op, no error
+
+
+# ── bcrypt shim ──────────────────────────────────────────────────────────────
+
+
+class TestBcryptShim:
+    def test_password_hash_and_verify(self):
+        from src.dependencies import get_password_hash, verify_password
+
+        hashed = get_password_hash("Sup3r!secret")
+        assert verify_password("Sup3r!secret", hashed)
+        assert not verify_password("wrong", hashed)
+
+    def test_bcrypt_about_shim_present(self):
+        import bcrypt
+
+        # The shim ensures passlib can read the version without warning.
+        assert hasattr(bcrypt, "__about__")
+        assert hasattr(bcrypt.__about__, "__version__")


### PR DESCRIPTION
Production-readiness hardening from a codebase audit. Four focused, low-risk improvements (all tested).

## Observability — fix dead metrics
The custom Prometheus collectors were **defined but never incremented** (monitoring blind spot). Moved them to `src/metrics.py` (avoids circular imports) and wired recorders:
- `plaidify_blueprint_extractions_total{site,status}` — success/error in the engine
- `plaidify_mfa_challenges_total{mfa_type}` — on MFA detection
- `plaidify_browser_pool_active_contexts` — gauge on acquire/release

## Security — MFA brute-force guard
`POST /mfa/submit` was unthrottled. Added `RATE_LIMIT_MFA` (default **5/min/IP**).

## Operability — registration gate + first-user bootstrap
- `REGISTRATION_ENABLED` gates `/auth/register` (default `true`; logs a warning when left on in production).
- Idempotent env-driven bootstrap (`BOOTSTRAP_USER_USERNAME/EMAIL/PASSWORD`) creates the initial account on startup — no open registration or DB surgery needed.

## Hygiene — silence the bcrypt warning
Shim `bcrypt.__about__` so passlib 1.7.4 stops logging `(trapped) error reading bcrypt version` on every hash (passlib has no newer release; root-cause shim, hashing unchanged).

## Validation
- +9 tests in `tests/test_prod_hardening.py`; full suite **813 passed / 8 skipped**; ruff clean.
- `.env.example` documents all new settings.

Addresses 4 of the audit's top findings (dead metrics, MFA rate limit, registration/bootstrap, bcrypt). Deferred (larger/riskier, recommended next): wire OpenTelemetry spans, circuit breakers for LLM/browser, request-time Redis/DB degradation handling.