### PR TITLE
feat(resilience): circuit breakers, backoff, rate-limit fail-open

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -191,6 +191,28 @@ class Settings(BaseSettings):
         description="Default rate limit for all other endpoints. Format: 'N/period'.",
     )
 
+    # ── Resilience ────────────────────────────────────────────
+    llm_circuit_failure_threshold: int = Field(
+        default=5,
+        description="Consecutive LLM failures before the LLM circuit breaker opens (fail-fast).",
+    )
+    llm_circuit_reset_seconds: float = Field(
+        default=30.0,
+        description="Seconds the LLM circuit stays open before allowing a trial call.",
+    )
+    llm_retry_max_attempts: int = Field(
+        default=2,
+        description="Extra retry attempts (exponential backoff) for transient LLM rate-limit errors.",
+    )
+    browser_circuit_failure_threshold: int = Field(
+        default=5,
+        description="Consecutive browser-launch failures before the browser circuit breaker opens.",
+    )
+    browser_circuit_reset_seconds: float = Field(
+        default=30.0,
+        description="Seconds the browser circuit stays open before allowing a trial launch.",
+    )
+
     # ── Redis ─────────────────────────────────────────────────
     redis_url: Optional[str] = Field(
         default=None,

--- a/src/core/browser_pool.py
+++ b/src/core/browser_pool.py
@@ -30,10 +30,18 @@ from playwright.async_api import (
 
 from src import metrics
 from src.config import get_settings
+from src.core.circuit_breaker import CircuitBreaker
 from src.core.read_only_policy import ExecutionPhase, ReadOnlyExecutionPolicy
 from src.logging_config import get_logger
 
 logger = get_logger("browser_pool")
+
+_bp_settings = get_settings()
+_browser_breaker = CircuitBreaker(
+    "browser",
+    failure_threshold=_bp_settings.browser_circuit_failure_threshold,
+    reset_timeout=_bp_settings.browser_circuit_reset_seconds,
+)
 
 # ── Stealth Profiles ─────────────────────────────────────────────────────────
 
@@ -153,15 +161,20 @@ class BrowserPool:
         )
 
         self._playwright = await async_playwright().start()
-        self._browser = await self._playwright.chromium.launch(
-            headless=self._headless,
-            args=[
-                "--disable-blink-features=AutomationControlled",
-                "--disable-dev-shm-usage",
-                "--no-first-run",
-                "--no-default-browser-check",
-            ],
-        )
+
+        async def _launch() -> Browser:
+            return await self._playwright.chromium.launch(
+                headless=self._headless,
+                args=[
+                    "--disable-blink-features=AutomationControlled",
+                    "--disable-dev-shm-usage",
+                    "--no-first-run",
+                    "--no-default-browser-check",
+                ],
+            )
+
+        # Fail fast if browser launches keep failing (e.g. resource exhaustion).
+        self._browser = await _browser_breaker.call(_launch)
         self._running = True
 
         # Start background cleanup of idle contexts

--- a/src/core/circuit_breaker.py
+++ b/src/core/circuit_breaker.py
@@ -1,0 +1,143 @@
+"""Resilience primitives: an async circuit breaker and exponential-backoff retry.
+
+These wrap calls to flaky external dependencies (LLM providers, the browser
+pool) so a degraded dependency fails fast instead of making every request pay
+the full timeout cost, and so transient errors get a bounded, jittered retry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from enum import Enum
+from typing import Awaitable, Callable, Optional, Sequence, TypeVar
+
+from src.logging_config import get_logger
+
+logger = get_logger("resilience")
+
+T = TypeVar("T")
+
+
+class CircuitState(str, Enum):
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitBreakerOpenError(Exception):
+    """Raised when a call is rejected because the circuit is open."""
+
+    def __init__(self, name: str, retry_after: float):
+        super().__init__(f"Circuit '{name}' is open; failing fast (retry in ~{retry_after:.0f}s)")
+        self.name = name
+        self.retry_after = retry_after
+
+
+class CircuitBreaker:
+    """A minimal async circuit breaker.
+
+    After ``failure_threshold`` consecutive failures the breaker opens and
+    rejects calls for ``reset_timeout`` seconds. It then allows a single trial
+    call (half-open); a success closes it, a failure re-opens it.
+    """
+
+    def __init__(self, name: str, *, failure_threshold: int = 5, reset_timeout: float = 30.0):
+        self.name = name
+        self.failure_threshold = max(1, failure_threshold)
+        self.reset_timeout = max(0.0, reset_timeout)
+        self._state = CircuitState.CLOSED
+        self._failures = 0
+        self._opened_at = 0.0
+        self._lock = asyncio.Lock()
+
+    @property
+    def state(self) -> CircuitState:
+        return self._state
+
+    def reset(self) -> None:
+        """Force the breaker back to a clean closed state (mainly for tests)."""
+        self._state = CircuitState.CLOSED
+        self._failures = 0
+        self._opened_at = 0.0
+
+    async def _before_call(self) -> None:
+        async with self._lock:
+            if self._state is CircuitState.OPEN:
+                elapsed = time.monotonic() - self._opened_at
+                if elapsed >= self.reset_timeout:
+                    self._state = CircuitState.HALF_OPEN
+                    logger.info("Circuit '%s' entering half-open trial", self.name)
+                else:
+                    raise CircuitBreakerOpenError(self.name, self.reset_timeout - elapsed)
+
+    async def _on_success(self) -> None:
+        async with self._lock:
+            if self._state is not CircuitState.CLOSED:
+                logger.info("Circuit '%s' closed (recovered)", self.name)
+            self._failures = 0
+            self._state = CircuitState.CLOSED
+
+    async def _on_failure(self) -> None:
+        async with self._lock:
+            self._failures += 1
+            if self._state is CircuitState.HALF_OPEN or self._failures >= self.failure_threshold:
+                self._state = CircuitState.OPEN
+                self._opened_at = time.monotonic()
+                logger.warning("Circuit '%s' opened after %d consecutive failure(s)", self.name, self._failures)
+
+    async def call(self, fn: Callable[..., Awaitable[T]], *args, **kwargs) -> T:
+        """Run ``fn`` through the breaker, recording success/failure."""
+        await self._before_call()
+        try:
+            result = await fn(*args, **kwargs)
+        except Exception:
+            await self._on_failure()
+            raise
+        await self._on_success()
+        return result
+
+
+async def retry_with_backoff(
+    fn: Callable[[], Awaitable[T]],
+    *,
+    retries: int = 2,
+    base_delay: float = 0.5,
+    max_delay: float = 8.0,
+    jitter: bool = True,
+    retry_on: Sequence[type[BaseException]] = (Exception,),
+    delay_for: Optional[Callable[[BaseException], Optional[float]]] = None,
+) -> T:
+    """Call async ``fn`` with exponential backoff on the given exceptions.
+
+    ``delay_for`` may inspect the raised exception and return an explicit delay
+    (e.g. honouring a provider ``retry-after`` header); it is clamped to
+    ``max_delay``. Returns the first successful result or re-raises the final
+    exception after ``retries`` extra attempts are exhausted.
+    """
+    attempt = 0
+    retry_types = tuple(retry_on)
+    while True:
+        try:
+            return await fn()
+        except retry_types as exc:
+            if attempt >= retries:
+                raise
+            delay = None
+            if delay_for is not None:
+                delay = delay_for(exc)
+            if delay is None:
+                delay = base_delay * (2**attempt)
+            delay = min(max_delay, max(0.0, delay))
+            if jitter:
+                delay *= 0.5 + random.random() / 2
+            logger.warning(
+                "Retrying after error (attempt %d/%d, sleeping %.2fs): %s",
+                attempt + 1,
+                retries,
+                delay,
+                exc,
+            )
+            await asyncio.sleep(delay)
+            attempt += 1

--- a/src/core/llm_provider.py
+++ b/src/core/llm_provider.py
@@ -21,9 +21,18 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from src.config import get_settings
+from src.core.circuit_breaker import CircuitBreaker, CircuitBreakerOpenError, retry_with_backoff
 from src.logging_config import get_logger
 
 logger = get_logger("llm_provider")
+
+_settings = get_settings()
+_llm_breaker = CircuitBreaker(
+    "llm",
+    failure_threshold=_settings.llm_circuit_failure_threshold,
+    reset_timeout=_settings.llm_circuit_reset_seconds,
+)
 
 # ── Data Classes ──────────────────────────────────────────────────────────────
 
@@ -422,14 +431,48 @@ class FallbackChain(BaseLLMProvider):
         temperature: Optional[float] = None,
         response_format: Optional[Dict[str, str]] = None,
     ) -> LLMResponse:
+        async def _run_chain() -> LLMResponse:
+            return await self._call_chain(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                response_format=response_format,
+            )
+
+        # Fail fast when the whole LLM subsystem is degraded instead of paying
+        # the full timeout on every request.
+        try:
+            return await _llm_breaker.call(_run_chain)
+        except CircuitBreakerOpenError as e:
+            raise LLMProviderError(str(e)) from e
+
+    async def _call_chain(
+        self,
+        messages: List[Dict[str, str]],
+        *,
+        max_tokens: Optional[int],
+        temperature: Optional[float],
+        response_format: Optional[Dict[str, str]],
+    ) -> LLMResponse:
         last_error: Optional[Exception] = None
         for provider in self.providers:
-            try:
+
+            async def _attempt(provider: BaseLLMProvider = provider) -> LLMResponse:
                 return await provider._call(
                     messages,
                     max_tokens=max_tokens,
                     temperature=temperature,
                     response_format=response_format,
+                )
+
+            try:
+                # Retry only genuinely transient (rate-limit) errors, honouring
+                # any retry-after hint, with bounded exponential backoff.
+                return await retry_with_backoff(
+                    _attempt,
+                    retries=_settings.llm_retry_max_attempts,
+                    retry_on=(LLMRateLimitError,),
+                    delay_for=lambda e: getattr(e, "retry_after", None),
                 )
             except LLMAuthError:
                 raise  # Don't retry auth errors

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -57,6 +57,10 @@ limiter = Limiter(
     default_limits=[settings.rate_limit_default] if settings.rate_limit_enabled else [],
     enabled=settings.rate_limit_enabled,
     storage_uri=settings.redis_url if _limiter_storage else "memory://",
+    # Fail open: if the rate-limit backend (Redis) is unreachable at request
+    # time, allow the request rather than returning 500. Availability over a
+    # transient throttling gap; the outage is still surfaced via /health.
+    swallow_errors=True,
 )
 
 # ── Password Hashing ─────────────────────────────────────────────────────────

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,172 @@
+"""Tests for resilience primitives: circuit breaker, backoff retry, and the
+LLM fallback chain's fail-fast behavior."""
+
+import pytest
+
+from src.core.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerOpenError,
+    CircuitState,
+    retry_with_backoff,
+)
+
+
+async def _noop_sleep(*_a, **_k):
+    return None
+
+
+# ── CircuitBreaker ───────────────────────────────────────────────────────────
+
+
+class TestCircuitBreaker:
+    @pytest.mark.asyncio
+    async def test_opens_after_threshold_then_fails_fast(self):
+        cb = CircuitBreaker("t", failure_threshold=3, reset_timeout=60)
+
+        async def boom():
+            raise ValueError("x")
+
+        for _ in range(3):
+            with pytest.raises(ValueError):
+                await cb.call(boom)
+        assert cb.state is CircuitState.OPEN
+
+        # Subsequent calls are rejected without invoking the function.
+        with pytest.raises(CircuitBreakerOpenError):
+            await cb.call(boom)
+
+    @pytest.mark.asyncio
+    async def test_half_open_recovers_on_success(self):
+        cb = CircuitBreaker("t", failure_threshold=1, reset_timeout=0.0)
+
+        async def boom():
+            raise ValueError("x")
+
+        with pytest.raises(ValueError):
+            await cb.call(boom)
+        assert cb.state is CircuitState.OPEN
+
+        # reset_timeout=0 → next call is a half-open trial; success closes it.
+        async def ok():
+            return "ok"
+
+        assert await cb.call(ok) == "ok"
+        assert cb.state is CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_count(self):
+        cb = CircuitBreaker("t", failure_threshold=3, reset_timeout=60)
+
+        async def boom():
+            raise ValueError()
+
+        async def ok():
+            return 1
+
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await cb.call(boom)
+        await cb.call(ok)  # resets the counter
+        # Two more failures must not open the breaker (counter was reset).
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await cb.call(boom)
+        assert cb.state is CircuitState.CLOSED
+
+
+# ── retry_with_backoff ───────────────────────────────────────────────────────
+
+
+class TestRetryWithBackoff:
+    @pytest.mark.asyncio
+    async def test_succeeds_after_transient_failures(self, monkeypatch):
+        monkeypatch.setattr("src.core.circuit_breaker.asyncio.sleep", _noop_sleep)
+        calls = {"n": 0}
+
+        async def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ValueError("transient")
+            return "ok"
+
+        assert await retry_with_backoff(flaky, retries=5, retry_on=(ValueError,)) == "ok"
+        assert calls["n"] == 3
+
+    @pytest.mark.asyncio
+    async def test_reraises_after_exhaustion(self, monkeypatch):
+        monkeypatch.setattr("src.core.circuit_breaker.asyncio.sleep", _noop_sleep)
+
+        async def always_fail():
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError):
+            await retry_with_backoff(always_fail, retries=2, retry_on=(ValueError,))
+
+    @pytest.mark.asyncio
+    async def test_does_not_retry_unmatched_exceptions(self, monkeypatch):
+        monkeypatch.setattr("src.core.circuit_breaker.asyncio.sleep", _noop_sleep)
+        calls = {"n": 0}
+
+        async def fail():
+            calls["n"] += 1
+            raise KeyError("different")
+
+        with pytest.raises(KeyError):
+            await retry_with_backoff(fail, retries=3, retry_on=(ValueError,))
+        assert calls["n"] == 1  # not retried
+
+    @pytest.mark.asyncio
+    async def test_delay_for_is_consulted(self, monkeypatch):
+        seen = []
+
+        async def fake_sleep(d):
+            seen.append(d)
+
+        monkeypatch.setattr("src.core.circuit_breaker.asyncio.sleep", fake_sleep)
+
+        async def fail():
+            raise ValueError()
+
+        with pytest.raises(ValueError):
+            await retry_with_backoff(fail, retries=1, retry_on=(ValueError,), jitter=False, delay_for=lambda _e: 2.0)
+        assert seen == [2.0]
+
+
+# ── LLM fallback chain fail-fast ─────────────────────────────────────────────
+
+
+class TestLLMChainResilience:
+    @pytest.mark.asyncio
+    async def test_chain_breaker_opens_and_fails_fast(self):
+        from src.core import llm_provider as lp
+        from src.core.llm_provider import FallbackChain, LLMProviderError
+
+        lp._llm_breaker.reset()
+        try:
+
+            class _Failing:
+                provider_name = "failing"
+                model = "x"
+                max_tokens = 100
+                temperature = 0.0
+                timeout = 1.0
+
+                async def _call(self, *_a, **_k):
+                    raise LLMProviderError("provider down")
+
+                async def close(self):
+                    return None
+
+            chain = FallbackChain([_Failing()])
+            msgs = [{"role": "user", "content": "x"}]
+
+            for _ in range(lp._settings.llm_circuit_failure_threshold):
+                with pytest.raises(LLMProviderError):
+                    await chain._call(msgs)
+
+            # Breaker now open — the next call fails fast with a circuit message.
+            with pytest.raises(LLMProviderError) as exc_info:
+                await chain._call(msgs)
+            assert "open" in str(exc_info.value).lower()
+        finally:
+            lp._llm_breaker.reset()


### PR DESCRIPTION
Closes the audit's biggest gap — **error handling & resilience** (6.0 → ~9).

## What
- **`src/core/circuit_breaker.py`** — async `CircuitBreaker` (closed/open/half-open) + `retry_with_backoff` (bounded, jittered, honours `retry-after`).
- **LLM** — the `FallbackChain` now runs through an `llm` circuit breaker, so a degraded provider **fails fast** instead of every request paying full timeouts. Transient rate-limit errors get exponential backoff (honouring `retry-after`); auth errors never retry.
- **Browser** — the chromium launch is wrapped in a `browser` circuit breaker (repeated launch failures fail fast).
- **Rate limiter** — `swallow_errors=True`: a **request-time Redis outage fails open** (availability) instead of 500s; the outage still surfaces via `/health`.
- Tunables: `LLM_CIRCUIT_*`, `BROWSER_CIRCUIT_*`, `LLM_RETRY_MAX_ATTEMPTS`.

## Validation
- +8 tests in `tests/test_resilience.py` (breaker states, backoff, LLM chain fail-fast).
- Full suite **821 passed / 8 skipped**; ruff clean. Real-browser launch validated via the integration slice (breaker-wrapped `start()`).