### PR TITLE
feat(observability): wire OpenTelemetry distributed tracing

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -55,6 +55,7 @@ from src.routers import (
     system,
     webhooks,
 )
+from src.tracing import init_tracing
 
 settings = get_settings()
 logger = get_logger("api")
@@ -252,6 +253,7 @@ async def lifespan(app: FastAPI):
 
     _validate_runtime_configuration()
     _initialize_sentry()
+    init_tracing(app, settings)
     init_db()
     _bootstrap_user()
 

--- a/src/core/engine.py
+++ b/src/core/engine.py
@@ -56,6 +56,7 @@ from src.exceptions import (
     ReadOnlyPolicyViolationError,
 )
 from src.logging_config import get_logger
+from src.tracing import span
 
 logger = get_logger("engine")
 settings = get_settings()
@@ -636,17 +637,18 @@ async def _execute_blueprint(
         extraction_method = "none"
 
         if extraction_defs:
-            if blueprint.is_llm_adaptive:
-                extracted_data, extraction_method = await _extract_llm_adaptive(
-                    page=page,
-                    blueprint=blueprint,
-                    extraction_defs=extraction_defs,
-                    site=site,
-                )
-            else:
-                extractor = DataExtractor(page)
-                extracted_data = await extractor.extract(extraction_defs, site=site)
-                extraction_method = "css_selectors"
+            with span("engine.extract", **{"plaidify.site": site}):
+                if blueprint.is_llm_adaptive:
+                    extracted_data, extraction_method = await _extract_llm_adaptive(
+                        page=page,
+                        blueprint=blueprint,
+                        extraction_defs=extraction_defs,
+                        site=site,
+                    )
+                else:
+                    extractor = DataExtractor(page)
+                    extracted_data = await extractor.extract(extraction_defs, site=site)
+                    extraction_method = "css_selectors"
 
         # ── Step 4: Cleanup (logout) ──────────────────────────────────────────
         if blueprint.cleanup:

--- a/src/core/llm_provider.py
+++ b/src/core/llm_provider.py
@@ -24,6 +24,7 @@ from typing import Any, Dict, List, Optional
 from src.config import get_settings
 from src.core.circuit_breaker import CircuitBreaker, CircuitBreakerOpenError, retry_with_backoff
 from src.logging_config import get_logger
+from src.tracing import tracer
 
 logger = get_logger("llm_provider")
 
@@ -155,12 +156,17 @@ class BaseLLMProvider(ABC):
 
         response_format = {"type": "json_object"} if json_mode else None
 
-        response = await self._call(
-            messages,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            response_format=response_format,
-        )
+        with tracer.start_as_current_span("llm.extract") as _span:
+            _span.set_attribute("llm.provider", self.provider_name)
+            _span.set_attribute("llm.model", self.model)
+            response = await self._call(
+                messages,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                response_format=response_format,
+            )
+            _span.set_attribute("llm.prompt_tokens", response.usage.prompt_tokens)
+            _span.set_attribute("llm.completion_tokens", response.usage.completion_tokens)
         logger.info(
             "LLM extraction complete: provider=%s model=%s prompt_tokens=%d completion_tokens=%d latency_ms=%.1f",
             self.provider_name,

--- a/src/tracing.py
+++ b/src/tracing.py
@@ -1,0 +1,97 @@
+"""OpenTelemetry tracing setup and a shared tracer.
+
+When ``OTEL_ENDPOINT`` is configured, :func:`init_tracing` wires a
+``TracerProvider`` with an OTLP/gRPC exporter and instruments the FastAPI app
+(automatic spans per HTTP request). When it isn't configured — or the OTel
+packages aren't installed — ``tracer`` is a no-op, so the spans sprinkled
+through the engine and LLM paths cost nothing.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+from src.logging_config import get_logger
+
+logger = get_logger("tracing")
+
+_initialized = False
+
+try:
+    from opentelemetry import trace as _otel_trace
+
+    tracer = _otel_trace.get_tracer("plaidify")
+    _OTEL_AVAILABLE = True
+except Exception:  # pragma: no cover - OTel API is normally installed
+    _otel_trace = None
+    _OTEL_AVAILABLE = False
+
+    class _NoopSpan:
+        def set_attribute(self, *_a, **_k):
+            return None
+
+        def record_exception(self, *_a, **_k):
+            return None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    class _NoopTracer:
+        def start_as_current_span(self, *_a, **_k):
+            return _NoopSpan()
+
+    tracer = _NoopTracer()
+
+
+def init_tracing(app, settings) -> bool:
+    """Initialize OTLP tracing + FastAPI instrumentation. Returns True if enabled."""
+    global _initialized
+    if _initialized or not _OTEL_AVAILABLE:
+        return _initialized
+    if not settings.otel_endpoint:
+        return False
+
+    try:
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        logger.warning("OpenTelemetry SDK/exporter not installed; tracing disabled")
+        return False
+
+    resource = Resource.create(
+        {
+            "service.name": settings.app_name.lower(),
+            "service.version": settings.app_version,
+            "deployment.environment": settings.env,
+        }
+    )
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter(endpoint=settings.otel_endpoint, insecure=True)))
+    _otel_trace.set_tracer_provider(provider)
+
+    try:
+        FastAPIInstrumentor.instrument_app(app)
+    except Exception as exc:  # pragma: no cover - instrumentation is best-effort
+        logger.warning("FastAPI OTel instrumentation failed: %s", exc)
+
+    _initialized = True
+    logger.info("OpenTelemetry tracing enabled (endpoint=%s)", settings.otel_endpoint)
+    return True
+
+
+@contextmanager
+def span(name: str, **attributes):
+    """Convenience context manager: start a span and set string/number attributes."""
+    with tracer.start_as_current_span(name) as sp:
+        for key, value in attributes.items():
+            try:
+                sp.set_attribute(key, value)
+            except Exception:  # pragma: no cover
+                pass
+        yield sp

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,0 +1,29 @@
+"""Tests for OpenTelemetry tracing wiring (safe no-op behavior when disabled)."""
+
+from types import SimpleNamespace
+
+
+class TestTracing:
+    def test_init_tracing_disabled_without_endpoint(self):
+        from src.tracing import init_tracing
+
+        fake_settings = SimpleNamespace(otel_endpoint=None, app_name="Plaidify", app_version="0.0", env="test")
+        assert init_tracing(object(), fake_settings) is False
+
+    def test_span_context_manager_is_safe(self):
+        from src.tracing import span
+
+        with span("test.span", **{"plaidify.test": "yes"}) as sp:
+            sp.set_attribute("extra", 1)
+        # Reaching here without raising is the assertion.
+
+    def test_tracer_start_span_is_safe(self):
+        from src.tracing import tracer
+
+        with tracer.start_as_current_span("noop") as sp:
+            sp.set_attribute("k", "v")
+
+    def test_llm_and_engine_import_tracer(self):
+        # Spans are wired into these hot paths; importing must not fail.
+        from src.core import engine, llm_provider  # noqa: F401
+        from src.tracing import span, tracer  # noqa: F401


### PR DESCRIPTION
`OTEL_ENDPOINT` was configured but never initialized — no distributed tracing existed. This wires it.

## What
- **`src/tracing.py`** — `init_tracing()` sets up an OTLP/gRPC `TracerProvider` + FastAPI auto-instrumentation when `OTEL_ENDPOINT` is set; otherwise `tracer`/`span` are no-ops (zero cost).
- Initialized from the app lifespan.
- Manual spans on latency-critical paths: **`llm.extract`** (provider/model/token attrs) and **`engine.extract`** (per-site). FastAPI gives per-request spans automatically.

## Validation
- +4 tests in `tests/test_tracing.py`; full suite **825 passed / 8 skipped**; ruff clean.