### PR TITLE
feat(authz): admin RBAC + session management

### DIFF
--- a/alembic/versions/o5p6q7r8s9t0_add_user_is_admin.py
+++ b/alembic/versions/o5p6q7r8s9t0_add_user_is_admin.py
@@ -1,0 +1,31 @@
+"""Add users.is_admin
+
+Revision ID: o5p6q7r8s9t0
+Revises: n4o5p6q7r8s9
+Create Date: 2026-06-23
+
+Adds a boolean ``is_admin`` flag to the users table to support
+administrator-only endpoints (RBAC). Defaults to false for all existing rows.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "o5p6q7r8s9t0"
+down_revision: Union[str, Sequence[str], None] = "n4o5p6q7r8s9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("is_admin", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "is_admin")

--- a/src/app.py
+++ b/src/app.py
@@ -42,6 +42,7 @@ from src.exceptions import PlaidifyError
 from src.logging_config import get_logger, setup_logging
 from src.routers import (
     access_jobs,
+    admin,
     agents,
     api_keys,
     audit,
@@ -135,7 +136,12 @@ def _bootstrap_user() -> None:
     try:
         existing = db.query(User).filter((User.username == username) | (User.email == email)).first()
         if existing:
-            logger.info("Bootstrap user already present; skipping creation")
+            if not existing.is_admin:
+                existing.is_admin = True
+                db.commit()
+                logger.info("Bootstrap user promoted to admin")
+            else:
+                logger.info("Bootstrap user already present; skipping creation")
             return
         db.add(
             User(
@@ -143,10 +149,11 @@ def _bootstrap_user() -> None:
                 email=email,
                 hashed_password=get_password_hash(password),
                 encrypted_dek=create_user_dek(),
+                is_admin=True,
             )
         )
         db.commit()
-        logger.info("Bootstrap user created", extra={"extra_data": {"username": username}})
+        logger.info("Bootstrap admin user created", extra={"extra_data": {"username": username}})
     except Exception as exc:  # pragma: no cover - bootstrap must not block startup
         logger.error(f"Bootstrap user creation failed: {exc}")
     finally:
@@ -476,6 +483,7 @@ for router in (
     registry.router,
     refresh.router,
     agents.router,
+    admin.router,
 ):
     app.include_router(router)
 

--- a/src/database.py
+++ b/src/database.py
@@ -405,6 +405,7 @@ class User(Base):
     oauth_provider = Column(String, nullable=True)  # e.g., 'google', 'github'
     oauth_sub = Column(String, nullable=True)  # Provider's user ID
     is_active = Column(Boolean, default=True)
+    is_admin = Column(Boolean, default=False, nullable=False)
     created_at = Column(DateTime, default=lambda: datetime.now(timezone.utc))
     # Envelope encryption: per-user DEK wrapped by master key (base64url)
     encrypted_dek = Column(Text, nullable=True)

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -233,6 +233,16 @@ def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(
     return user
 
 
+def get_admin_user(user: User = Depends(get_current_user)) -> User:
+    """FastAPI dependency: require the current user to be an administrator."""
+    if not getattr(user, "is_admin", False):
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Administrator access required.",
+        )
+    return user
+
+
 def get_current_user_or_api_key(request: Request, db: Session = Depends(get_db)) -> User:
     """FastAPI dependency: authenticate via JWT Bearer token OR X-API-Key header."""
     # Check for API key first

--- a/src/routers/admin.py
+++ b/src/routers/admin.py
@@ -1,0 +1,75 @@
+"""Administrator-only endpoints (RBAC). Requires an admin user (is_admin)."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from src.audit import record_audit_event
+from src.database import User, get_db
+from src.dependencies import get_admin_user
+from src.logging_config import get_logger
+
+logger = get_logger("api.admin")
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+def _serialize_user(u: User) -> dict:
+    return {
+        "id": u.id,
+        "username": u.username,
+        "email": u.email,
+        "is_active": bool(u.is_active),
+        "is_admin": bool(u.is_admin),
+        "created_at": u.created_at.isoformat() if u.created_at else None,
+    }
+
+
+@router.get("/users")
+async def list_users(
+    admin: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """List all users (admin only)."""
+    users = db.query(User).order_by(User.id).all()
+    return {"users": [_serialize_user(u) for u in users], "count": len(users)}
+
+
+@router.post("/users/{user_id}/promote")
+async def promote_user(
+    user_id: int,
+    admin: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Grant administrator rights to a user (admin only)."""
+    target = db.query(User).filter(User.id == user_id).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found.")
+    target.is_admin = True
+    db.commit()
+    record_audit_event(db, "admin", "promote_user", user_id=admin.id, metadata={"target_user_id": user_id})
+    return {"status": "promoted", "user_id": user_id}
+
+
+@router.post("/users/{user_id}/set-active")
+async def set_user_active(
+    user_id: int,
+    active: bool,
+    admin: User = Depends(get_admin_user),
+    db: Session = Depends(get_db),
+):
+    """Activate or deactivate a user account (admin only)."""
+    target = db.query(User).filter(User.id == user_id).first()
+    if not target:
+        raise HTTPException(status_code=404, detail="User not found.")
+    if target.id == admin.id and not active:
+        raise HTTPException(status_code=400, detail="Admins cannot deactivate their own account.")
+    target.is_active = active
+    db.commit()
+    record_audit_event(
+        db,
+        "admin",
+        "set_user_active",
+        user_id=admin.id,
+        metadata={"target_user_id": user_id, "active": active},
+    )
+    return {"status": "updated", "user_id": user_id, "is_active": active}

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -305,9 +305,7 @@ def list_sessions(user: User = Depends(get_current_user), db: Session = Depends(
 
 
 @router.post("/sessions/revoke-all")
-def revoke_all_sessions(
-    request: Request, user: User = Depends(get_current_user), db: Session = Depends(get_db)
-):
+def revoke_all_sessions(request: Request, user: User = Depends(get_current_user), db: Session = Depends(get_db)):
     """Revoke all of the current user's refresh tokens (force logout everywhere)."""
     count = (
         db.query(RefreshToken)

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -275,3 +275,53 @@ def refresh_tokens(request: Request, body: RefreshTokenRequest, db: Session = De
     db.commit()
 
     return issue_token_pair(token_record.user_id, db)
+
+
+@router.get("/sessions")
+def list_sessions(user: User = Depends(get_current_user), db: Session = Depends(get_db)):
+    """List the current user's active (non-revoked, unexpired) refresh-token sessions."""
+    now = datetime.now(timezone.utc)
+    tokens = (
+        db.query(RefreshToken)
+        .filter(
+            RefreshToken.user_id == user.id,
+            RefreshToken.revoked == False,  # noqa: E712
+            RefreshToken.expires_at > now,
+        )
+        .order_by(RefreshToken.created_at.desc())
+        .all()
+    )
+    return {
+        "sessions": [
+            {
+                "id": t.id,
+                "created_at": t.created_at.isoformat() if t.created_at else None,
+                "expires_at": t.expires_at.isoformat() if t.expires_at else None,
+            }
+            for t in tokens
+        ],
+        "count": len(tokens),
+    }
+
+
+@router.post("/sessions/revoke-all")
+def revoke_all_sessions(
+    request: Request, user: User = Depends(get_current_user), db: Session = Depends(get_db)
+):
+    """Revoke all of the current user's refresh tokens (force logout everywhere)."""
+    count = (
+        db.query(RefreshToken)
+        .filter(RefreshToken.user_id == user.id, RefreshToken.revoked == False)  # noqa: E712
+        .update({RefreshToken.revoked: True}, synchronize_session=False)
+    )
+    db.commit()
+    record_audit_event(
+        db,
+        "auth",
+        "revoke_all_sessions",
+        user_id=user.id,
+        metadata={"revoked_count": count},
+        ip_address=request.client.host if request.client else None,
+    )
+    logger.info("All sessions revoked", extra={"extra_data": {"user_id": user.id, "count": count}})
+    return {"status": "revoked", "count": count}

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -1,0 +1,135 @@
+"""Tests for admin RBAC and session management."""
+
+from unittest.mock import patch
+
+
+def _register(client, username, password="TestPass123!"):
+    r = client.post(
+        "/auth/register",
+        json={"username": username, "email": f"{username}@plaidify.dev", "password": password},
+    )
+    assert r.status_code == 200, r.text
+    return r.json()
+
+
+def _db_session(client):
+    """Open a session on the test database (same engine the API uses)."""
+    from src.database import get_db
+
+    gen = client.app.dependency_overrides[get_db]()
+    return next(gen), gen
+
+
+def _make_admin(client, username):
+    from src.database import User
+
+    db, gen = _db_session(client)
+    try:
+        user = db.query(User).filter(User.username == username).first()
+        user.is_admin = True
+        db.commit()
+    finally:
+        gen.close()
+
+
+def _user_id(client, username):
+    from src.database import User
+
+    db, gen = _db_session(client)
+    try:
+        return db.query(User).filter(User.username == username).first().id
+    finally:
+        gen.close()
+
+
+# ── Admin RBAC ───────────────────────────────────────────────────────────────
+
+
+class TestAdminRBAC:
+    def test_new_user_is_not_admin(self, client):
+        token = _register(client, "rbac_normal")["access_token"]
+        r = client.get("/admin/users", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 403
+
+    def test_admin_can_list_users(self, client):
+        token = _register(client, "rbac_admin")["access_token"]
+        _make_admin(client, "rbac_admin")
+        r = client.get("/admin/users", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200
+        assert r.json()["count"] >= 1
+
+    def test_admin_can_promote_user(self, client):
+        admin_token = _register(client, "rbac_admin2")["access_token"]
+        _make_admin(client, "rbac_admin2")
+        _register(client, "rbac_target")
+        target_id = _user_id(client, "rbac_target")
+
+        r = client.post(
+            f"/admin/users/{target_id}/promote",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 200
+
+        listing = client.get("/admin/users", headers={"Authorization": f"Bearer {admin_token}"}).json()
+        promoted = next(u for u in listing["users"] if u["id"] == target_id)
+        assert promoted["is_admin"] is True
+
+    def test_admin_cannot_deactivate_self(self, client):
+        admin_token = _register(client, "rbac_admin3")["access_token"]
+        _make_admin(client, "rbac_admin3")
+        admin_id = _user_id(client, "rbac_admin3")
+        r = client.post(
+            f"/admin/users/{admin_id}/set-active?active=false",
+            headers={"Authorization": f"Bearer {admin_token}"},
+        )
+        assert r.status_code == 400
+
+
+# ── Session management ───────────────────────────────────────────────────────
+
+
+class TestSessionManagement:
+    def test_list_and_revoke_all_sessions(self, client):
+        token = _register(client, "sess_user")["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
+        sessions = client.get("/auth/sessions", headers=headers).json()
+        assert sessions["count"] >= 1
+
+        revoked = client.post("/auth/sessions/revoke-all", headers=headers)
+        assert revoked.status_code == 200
+        assert revoked.json()["count"] >= 1
+
+        after = client.get("/auth/sessions", headers=headers).json()
+        assert after["count"] == 0
+
+    def test_revoke_all_invalidates_refresh_token(self, client):
+        reg = _register(client, "sess_user2")
+        headers = {"Authorization": f"Bearer {reg['access_token']}"}
+        client.post("/auth/sessions/revoke-all", headers=headers)
+        r = client.post("/auth/refresh", json={"refresh_token": reg["refresh_token"]})
+        assert r.status_code == 401
+
+
+# ── Bootstrap user becomes admin ─────────────────────────────────────────────
+
+
+class TestBootstrapAdmin:
+    def test_bootstrap_user_is_admin(self, client):
+        import src.app as appmod
+        from src.database import get_db
+
+        override = appmod.app.dependency_overrides.get(get_db)
+        with (
+            patch.object(appmod.settings, "bootstrap_user_username", "boot_admin"),
+            patch.object(appmod.settings, "bootstrap_user_email", "boot_admin@plaidify.dev"),
+            patch.object(appmod.settings, "bootstrap_user_password", "BootPass123!"),
+            patch.object(appmod, "get_db", override),
+        ):
+            appmod._bootstrap_user()
+
+        token = client.post("/auth/token", data={"username": "boot_admin", "password": "BootPass123!"}).json()[
+            "access_token"
+        ]
+        r = client.get("/admin/users", headers={"Authorization": f"Bearer {token}"})
+        assert r.status_code == 200


### PR DESCRIPTION
Adds an administrator role and user session control (audit findings: no admin concept, no force-logout).

## What
- **`users.is_admin`** column + alembic migration `o5p6q7r8s9t0` (up/down verified on a fresh DB).
- **`get_admin_user`** dependency + **`/admin`** router: `GET /admin/users`, `POST /admin/users/{id}/promote`, `POST /admin/users/{id}/set-active` (admins can't deactivate themselves).
- The **bootstrap user is now created/promoted as admin**, so operators get a real admin account without DB surgery.
- **Session management** on `/auth`: `GET /auth/sessions` (list active sessions) + `POST /auth/sessions/revoke-all` (force logout everywhere — compromised-token containment).

## Validation
- +7 tests in `tests/test_authz.py`; full suite **832 passed / 8 skipped**; migration up+down verified; ruff clean.