### PR TITLE
feat(auth): real OAuth2 social login (Google + GitHub)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,15 @@ POSTGRES_PASSWORD=
 # BOOTSTRAP_USER_EMAIL=admin@example.com
 # BOOTSTRAP_USER_PASSWORD=        # supply via secret store, not source control
 
+# ── OAuth2 Social Login ──────────────────────────────────────────────────────
+# Enable POST /auth/oauth2. Clients complete the provider's OAuth flow and post
+# the resulting access/ID token; Plaidify verifies it server-side.
+# OAUTH_ENABLED=false
+# OAUTH_ALLOWED_PROVIDERS=google,github
+# OAUTH_GOOGLE_CLIENT_ID=         # tokens are audience-checked against this
+# OAUTH_GITHUB_CLIENT_ID=
+# OAUTH_AUTO_REGISTER=true        # create an account on first verified login
+
 # ── Logging ──────────────────────────────────────────────────────────────────
 # LOG_LEVEL=INFO
 # LOG_FORMAT=json   # 'json' for production, 'text' for development

--- a/src/config.py
+++ b/src/config.py
@@ -85,6 +85,28 @@ class Settings(BaseSettings):
         description="JWT refresh token expiry in minutes.",
     )
 
+    # ── OAuth2 Social Login ───────────────────────────────────
+    oauth_enabled: bool = Field(
+        default=False,
+        description="Enable POST /auth/oauth2 social login (Google, GitHub).",
+    )
+    oauth_allowed_providers: str = Field(
+        default="google,github",
+        description="Comma-separated list of enabled OAuth providers.",
+    )
+    oauth_google_client_id: Optional[str] = Field(
+        default=None,
+        description="Google OAuth client id. When set, provider tokens are audience-checked against it.",
+    )
+    oauth_github_client_id: Optional[str] = Field(
+        default=None,
+        description="GitHub OAuth app client id (informational; GitHub tokens are app-scoped).",
+    )
+    oauth_auto_register: bool = Field(
+        default=True,
+        description="Auto-create a Plaidify account on first successful OAuth login with a verified email.",
+    )
+
     # ── Registration & Bootstrap ──────────────────────────────
     registration_enabled: bool = Field(
         default=True,

--- a/src/oauth_providers.py
+++ b/src/oauth_providers.py
@@ -1,0 +1,153 @@
+"""OAuth2 social-login provider verification.
+
+Verifies tokens issued by external identity providers (Google, GitHub) by
+calling each provider's server-side endpoints, and normalizes the result into
+an :class:`OAuthIdentity`. All network access is isolated in this module so it
+can be mocked in tests and so the route layer stays provider-agnostic.
+
+Security notes:
+- Google tokens are checked against the configured client id via the
+  ``tokeninfo`` endpoint, which returns the ``aud`` claim. This prevents
+  token-substitution ("confused deputy") attacks where a token minted for a
+  different application is replayed against Plaidify.
+- A verified email is required by the caller before an account is created or
+  linked, so email-based account linking is safe.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import httpx
+
+from src.logging_config import get_logger
+
+logger = get_logger("auth.oauth")
+
+_HTTP_TIMEOUT = 5.0
+
+GOOGLE_TOKENINFO_URL = "https://oauth2.googleapis.com/tokeninfo"
+GITHUB_USER_URL = "https://api.github.com/user"
+GITHUB_EMAILS_URL = "https://api.github.com/user/emails"
+
+
+@dataclass
+class OAuthIdentity:
+    """A normalized identity resolved from an external provider token."""
+
+    provider: str
+    subject: str  # stable, provider-assigned user id
+    email: Optional[str]
+    email_verified: bool
+    username: Optional[str]
+
+
+class OAuthVerificationError(Exception):
+    """Raised when a provider token cannot be verified or lacks required claims."""
+
+
+def verify_oauth_token(provider: str, token: str, settings: Any) -> OAuthIdentity:
+    """Verify an external provider token and return the resolved identity.
+
+    Args:
+        provider: Lower-cased provider name ("google" or "github").
+        token: The provider-issued access token or ID token from the client.
+        settings: Application settings (used for audience validation).
+
+    Raises:
+        OAuthVerificationError: If the token is invalid, the request fails, or
+            required claims (subject) are missing.
+    """
+    provider = (provider or "").lower()
+    if not token:
+        raise OAuthVerificationError("Empty OAuth token.")
+    if provider == "google":
+        return _verify_google(token, settings)
+    if provider == "github":
+        return _verify_github(token)
+    raise OAuthVerificationError(f"Unsupported OAuth provider: {provider!r}")
+
+
+def _http_get_json(
+    url: str,
+    *,
+    params: Optional[dict] = None,
+    bearer: Optional[str] = None,
+    accept: Optional[str] = None,
+) -> Any:
+    headers = {}
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    if accept:
+        headers["Accept"] = accept
+    try:
+        resp = httpx.get(url, params=params, headers=headers, timeout=_HTTP_TIMEOUT)
+    except httpx.HTTPError as exc:
+        raise OAuthVerificationError(f"Provider request failed: {exc}") from exc
+    if resp.status_code != 200:
+        raise OAuthVerificationError(f"Provider returned HTTP {resp.status_code}")
+    try:
+        return resp.json()
+    except ValueError as exc:
+        raise OAuthVerificationError("Provider returned a non-JSON response.") from exc
+
+
+def _verify_google(token: str, settings: Any) -> OAuthIdentity:
+    # tokeninfo accepts either an id_token or an access_token and returns the
+    # audience (`aud`) the token was minted for, enabling an audience check.
+    data: Optional[dict] = None
+    last_error: Optional[Exception] = None
+    for param in ("id_token", "access_token"):
+        try:
+            result = _http_get_json(GOOGLE_TOKENINFO_URL, params={param: token})
+            if isinstance(result, dict) and result.get("sub"):
+                data = result
+                break
+        except OAuthVerificationError as exc:
+            last_error = exc
+    if not data:
+        raise OAuthVerificationError(
+            f"Google token verification failed: {last_error}" if last_error else "Google token verification failed."
+        )
+
+    expected_aud = getattr(settings, "oauth_google_client_id", None)
+    if expected_aud and data.get("aud") != expected_aud:
+        raise OAuthVerificationError("Google token audience does not match the configured client id.")
+
+    subject = str(data.get("sub"))
+    email = data.get("email")
+    # tokeninfo returns email_verified as the strings "true"/"false".
+    email_verified = str(data.get("email_verified", "")).lower() == "true"
+    username = email.split("@", 1)[0] if email else None
+    return OAuthIdentity("google", subject, email, email_verified, username)
+
+
+def _verify_github(token: str) -> OAuthIdentity:
+    accept = "application/vnd.github+json"
+    profile = _http_get_json(GITHUB_USER_URL, bearer=token, accept=accept)
+    if not isinstance(profile, dict) or not profile.get("id"):
+        raise OAuthVerificationError("GitHub profile missing 'id'.")
+
+    subject = str(profile["id"])
+    username = profile.get("login")
+    email = profile.get("email")
+    email_verified = False
+
+    # GitHub's profile email is often null; the primary verified address lives
+    # behind /user/emails (requires the user:email scope).
+    try:
+        emails = _http_get_json(GITHUB_EMAILS_URL, bearer=token, accept=accept)
+        if isinstance(emails, list):
+            primary = next(
+                (e for e in emails if isinstance(e, dict) and e.get("primary") and e.get("verified")),
+                None,
+            )
+            if primary:
+                email = primary.get("email")
+                email_verified = True
+    except OAuthVerificationError:
+        # Missing user:email scope — fall back to the (possibly null) profile email.
+        logger.info("GitHub /user/emails unavailable; using profile email if present.")
+
+    return OAuthIdentity("github", subject, email, email_verified, username)

--- a/src/routers/auth.py
+++ b/src/routers/auth.py
@@ -39,6 +39,7 @@ from src.models import (
     UserProfileResponse,
     UserRegisterRequest,
 )
+from src.oauth_providers import OAuthVerificationError, verify_oauth_token
 
 settings = get_settings()
 logger = get_logger("api.auth")
@@ -212,21 +213,103 @@ def delete_account(
     return {"status": "deleted", "user_id": user_id, "removed": removed}
 
 
+def _unique_username(db: Session, base: str | None) -> str:
+    """Return a username derived from ``base`` that is unique in the users table."""
+    base = (base or "user").strip() or "user"
+    candidate = base
+    while db.query(User).filter(User.username == candidate).first() is not None:
+        candidate = f"{base}-{secrets.token_hex(3)}"
+    return candidate
+
+
 @router.post("/oauth2", response_model=TokenResponse)
 @limiter.limit(settings.rate_limit_auth)
 def oauth2_login(request: Request, body: OAuth2LoginRequest, db: Session = Depends(get_db)):
-    """
-    OAuth2 login endpoint (Google, GitHub, etc.).
+    """Authenticate with an external OAuth2 provider (Google, GitHub).
 
-    Disabled until real provider token verification is implemented.
-    To enable, implement provider-specific token validation (e.g. verify
-    Google ID tokens via Google's tokeninfo endpoint, GitHub tokens via
-    GitHub's /user API, etc.) and replace the guard below.
+    The client completes the provider's own OAuth flow, then posts the resulting
+    access/ID token here. Plaidify verifies the token server-side against the
+    provider, then issues its own JWT pair. A verified provider email is
+    required; first-time logins auto-provision an account when
+    ``OAUTH_AUTO_REGISTER`` is enabled.
     """
-    raise HTTPException(
-        status_code=501,
-        detail="OAuth2 login is not yet implemented. Configure provider-specific token verification before enabling.",
+    if not settings.oauth_enabled:
+        raise HTTPException(status_code=403, detail="OAuth login is disabled.")
+
+    provider = (body.provider or "").lower()
+    allowed = [p.strip().lower() for p in settings.oauth_allowed_providers.split(",") if p.strip()]
+    if provider not in allowed:
+        raise HTTPException(status_code=400, detail=f"Unsupported OAuth provider: {body.provider!r}")
+
+    ip_address = request.client.host if request.client else None
+
+    try:
+        identity = verify_oauth_token(provider, body.oauth_token, settings)
+    except OAuthVerificationError as exc:
+        record_audit_event(
+            db,
+            "auth",
+            "oauth_login_failed",
+            metadata={"provider": provider, "reason": str(exc)},
+            ip_address=ip_address,
+        )
+        raise HTTPException(status_code=401, detail="OAuth token verification failed.") from exc
+
+    if not identity.email or not identity.email_verified:
+        raise HTTPException(
+            status_code=403,
+            detail="A verified email from the provider is required to sign in.",
+        )
+
+    # 1) Match by provider identity (stable subject).
+    user = db.query(User).filter(User.oauth_provider == provider, User.oauth_sub == identity.subject).first()
+    # 2) Otherwise link to an existing account with the same verified email.
+    if not user:
+        user = db.query(User).filter(User.email == identity.email).first()
+        if user and not user.oauth_sub:
+            user.oauth_provider = provider
+            user.oauth_sub = identity.subject
+            db.commit()
+    # 3) Otherwise auto-provision a new account.
+    if not user:
+        if not settings.oauth_auto_register:
+            raise HTTPException(status_code=403, detail="No account is linked to this identity.")
+        user = User(
+            username=_unique_username(db, identity.username or identity.email.split("@", 1)[0]),
+            email=identity.email,
+            hashed_password=None,
+            oauth_provider=provider,
+            oauth_sub=identity.subject,
+            encrypted_dek=create_user_dek(),
+            is_active=True,
+        )
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        record_audit_event(
+            db,
+            "auth",
+            "oauth_register",
+            user_id=user.id,
+            metadata={"provider": provider},
+            ip_address=ip_address,
+        )
+        logger.info("OAuth user registered", extra={"extra_data": {"user_id": user.id, "provider": provider}})
+
+    if not user.is_active:
+        raise HTTPException(status_code=403, detail="Account is disabled.")
+
+    ensure_user_dek(user, db)
+    record_audit_event(
+        db,
+        "auth",
+        "oauth_login",
+        user_id=user.id,
+        metadata={"provider": provider},
+        ip_address=ip_address,
     )
+    logger.info("OAuth login", extra={"extra_data": {"user_id": user.id, "provider": provider}})
+    return issue_token_pair(user.id, db)
 
 
 @router.post("/forgot-password")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -156,9 +156,9 @@ class TestProfile:
 
 
 class TestOAuth2:
-    """Tests for POST /auth/oauth2 (currently disabled — returns 501)."""
+    """Tests for POST /auth/oauth2 (disabled by default — returns 403)."""
 
-    def test_oauth2_login_returns_not_implemented(self, client):
+    def test_oauth2_disabled_by_default_returns_403(self, client):
         response = client.post(
             "/auth/oauth2",
             json={
@@ -166,8 +166,8 @@ class TestOAuth2:
                 "oauth_token": "google-token-abc12345",
             },
         )
-        assert response.status_code == 501
-        assert "not yet implemented" in response.json()["detail"].lower()
+        assert response.status_code == 403
+        assert "disabled" in response.json()["detail"].lower()
 
 
 class TestAccountLockout:

--- a/tests/test_envelope_encryption.py
+++ b/tests/test_envelope_encryption.py
@@ -226,8 +226,8 @@ class TestRegistrationCreatesDEK:
         finally:
             db.close()
 
-    def test_oauth2_disabled_returns_501(self, client):
-        """OAuth2 endpoint is disabled until real provider validation is implemented."""
+    def test_oauth2_disabled_returns_403(self, client):
+        """OAuth2 social login is disabled by default (OAUTH_ENABLED=false)."""
         response = client.post(
             "/auth/oauth2",
             json={
@@ -235,7 +235,7 @@ class TestRegistrationCreatesDEK:
                 "oauth_token": "fake-google-token-dek-test",
             },
         )
-        assert response.status_code == 501
+        assert response.status_code == 403
 
 
 class TestLazyDEKMigration:

--- a/tests/test_jwt_refresh.py
+++ b/tests/test_jwt_refresh.py
@@ -47,8 +47,8 @@ class TestTokenResponseIncludesRefresh:
         assert "refresh_token" in data
         assert len(data["refresh_token"]) > 20
 
-    def test_oauth2_disabled_returns_501(self, client):
-        """OAuth2 is disabled until real provider validation is implemented."""
+    def test_oauth2_disabled_returns_403(self, client):
+        """OAuth2 social login is disabled by default (OAUTH_ENABLED=false)."""
         response = client.post(
             "/auth/oauth2",
             json={
@@ -56,7 +56,7 @@ class TestTokenResponseIncludesRefresh:
                 "oauth_token": "fake-google-token-12345678",
             },
         )
-        assert response.status_code == 501
+        assert response.status_code == 403
 
 
 class TestRefreshEndpoint:

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -1,0 +1,204 @@
+"""Tests for OAuth2 social login (POST /auth/oauth2) and provider verification."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.oauth_providers import (
+    OAuthIdentity,
+    OAuthVerificationError,
+    verify_oauth_token,
+)
+
+
+def _db(client):
+    from src.database import get_db
+
+    gen = client.app.dependency_overrides[get_db]()
+    return next(gen), gen
+
+
+def _identity(provider="google", subject="sub-123", email="alice@example.com", verified=True, username="alice"):
+    return OAuthIdentity(
+        provider=provider,
+        subject=subject,
+        email=email,
+        email_verified=verified,
+        username=username,
+    )
+
+
+# ── Endpoint behavior ─────────────────────────────────────────────────────────
+
+
+def test_oauth2_disabled_returns_403(client):
+    with patch("src.routers.auth.settings.oauth_enabled", False):
+        resp = client.post("/auth/oauth2", json={"provider": "google", "oauth_token": "t"})
+    assert resp.status_code == 403
+
+
+def test_oauth2_unsupported_provider_returns_400(client):
+    with patch("src.routers.auth.settings.oauth_enabled", True):
+        resp = client.post("/auth/oauth2", json={"provider": "myspace", "oauth_token": "t"})
+    assert resp.status_code == 400
+
+
+def test_oauth2_verification_failure_returns_401(client):
+    with (
+        patch("src.routers.auth.settings.oauth_enabled", True),
+        patch("src.routers.auth.verify_oauth_token", side_effect=OAuthVerificationError("bad")),
+    ):
+        resp = client.post("/auth/oauth2", json={"provider": "google", "oauth_token": "t"})
+    assert resp.status_code == 401
+
+
+def test_oauth2_unverified_email_returns_403(client):
+    with (
+        patch("src.routers.auth.settings.oauth_enabled", True),
+        patch("src.routers.auth.verify_oauth_token", return_value=_identity(verified=False)),
+    ):
+        resp = client.post("/auth/oauth2", json={"provider": "google", "oauth_token": "t"})
+    assert resp.status_code == 403
+
+
+def test_oauth2_auto_registers_new_user(client):
+    from src.database import User
+
+    with (
+        patch("src.routers.auth.settings.oauth_enabled", True),
+        patch("src.routers.auth.verify_oauth_token", return_value=_identity()),
+    ):
+        resp = client.post("/auth/oauth2", json={"provider": "google", "oauth_token": "t"})
+
+    assert resp.status_code == 200, resp.text
+    assert "access_token" in resp.json()
+
+    db, gen = _db(client)
+    try:
+        user = db.query(User).filter(User.email == "alice@example.com").first()
+        assert user is not None
+        assert user.oauth_provider == "google"
+        assert user.oauth_sub == "sub-123"
+        assert user.hashed_password is None
+    finally:
+        gen.close()
+
+
+def test_oauth2_repeat_login_does_not_duplicate(client):
+    from src.database import User
+
+    with (
+        patch("src.routers.auth.settings.oauth_enabled", True),
+        patch("src.routers.auth.verify_oauth_token", return_value=_identity()),
+    ):
+        first = client.post("/auth/oauth2", json={"provider": "google", "oauth_token": "t"})
+        second = client.post("/auth/oauth2", json={"provider": "google", "oauth_token": "t"})
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    db, gen = _db(client)
+    try:
+        count = db.query(User).filter(User.email == "alice@example.com").count()
+        assert count == 1
+    finally:
+        gen.close()
+
+
+def test_oauth2_links_existing_email_account(client, auth_headers):
+    """A verified OAuth email matching an existing user links rather than duplicates."""
+    from src.database import User
+
+    # auth_headers registered testuser with test@example.com
+    identity = _identity(email="test@example.com", subject="gh-999", provider="github", username="testuser")
+    with (
+        patch("src.routers.auth.settings.oauth_enabled", True),
+        patch("src.routers.auth.verify_oauth_token", return_value=identity),
+    ):
+        resp = client.post("/auth/oauth2", json={"provider": "github", "oauth_token": "t"})
+
+    assert resp.status_code == 200
+    db, gen = _db(client)
+    try:
+        users = db.query(User).filter(User.email == "test@example.com").all()
+        assert len(users) == 1
+        assert users[0].oauth_provider == "github"
+        assert users[0].oauth_sub == "gh-999"
+    finally:
+        gen.close()
+
+
+def test_oauth2_no_autoregister_without_account_returns_403(client):
+    with (
+        patch("src.routers.auth.settings.oauth_enabled", True),
+        patch("src.routers.auth.settings.oauth_auto_register", False),
+        patch("src.routers.auth.verify_oauth_token", return_value=_identity()),
+    ):
+        resp = client.post("/auth/oauth2", json={"provider": "google", "oauth_token": "t"})
+    assert resp.status_code == 403
+
+
+# ── Provider module unit tests ────────────────────────────────────────────────
+
+
+class _FakeResp:
+    def __init__(self, status_code, payload):
+        self.status_code = status_code
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+def test_verify_google_success_with_audience_check():
+    settings = SimpleNamespace(oauth_google_client_id="client-abc")
+    payload = {"sub": "g-1", "aud": "client-abc", "email": "bob@example.com", "email_verified": "true"}
+
+    with patch("src.oauth_providers.httpx.get", return_value=_FakeResp(200, payload)):
+        identity = verify_oauth_token("google", "id-token", settings)
+
+    assert identity.provider == "google"
+    assert identity.subject == "g-1"
+    assert identity.email == "bob@example.com"
+    assert identity.email_verified is True
+    assert identity.username == "bob"
+
+
+def test_verify_google_audience_mismatch_raises():
+    settings = SimpleNamespace(oauth_google_client_id="expected-client")
+    payload = {"sub": "g-1", "aud": "someone-elses-client", "email": "bob@example.com", "email_verified": "true"}
+
+    with patch("src.oauth_providers.httpx.get", return_value=_FakeResp(200, payload)):
+        with pytest.raises(OAuthVerificationError):
+            verify_oauth_token("google", "id-token", settings)
+
+
+def test_verify_github_uses_verified_primary_email():
+    settings = SimpleNamespace()
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        if url.endswith("/user"):
+            return _FakeResp(200, {"id": 42, "login": "octocat", "email": None})
+        if url.endswith("/user/emails"):
+            return _FakeResp(
+                200,
+                [
+                    {"email": "secondary@example.com", "primary": False, "verified": True},
+                    {"email": "octo@example.com", "primary": True, "verified": True},
+                ],
+            )
+        return _FakeResp(404, {})
+
+    with patch("src.oauth_providers.httpx.get", side_effect=fake_get):
+        identity = verify_oauth_token("github", "gh-token", settings)
+
+    assert identity.subject == "42"
+    assert identity.username == "octocat"
+    assert identity.email == "octo@example.com"
+    assert identity.email_verified is True
+
+
+def test_verify_unsupported_provider_raises():
+    with pytest.raises(OAuthVerificationError):
+        verify_oauth_token("myspace", "t", SimpleNamespace())


### PR DESCRIPTION
## Batch F — OAuth2 provider verification

Replaces the `501` OAuth2 stub with real, server-side provider verification — one of the items on the path to full production readiness.

### What's implemented
- **[src/oauth_providers.py](src/oauth_providers.py)** — verifies provider tokens server-side and normalizes them into an `OAuthIdentity`:
  - **Google:** `tokeninfo` endpoint with an **audience check** against `OAUTH_GOOGLE_CLIENT_ID` — prevents token-substitution (confused-deputy) attacks.
  - **GitHub:** `/user` + verified primary email from `/user/emails`.
  - All network calls isolated + timed out (5s) so they're mockable and can't hang.
- **`POST /auth/oauth2`** now: verifies the token, **requires a verified email**, links by provider-subject or verified email, and auto-provisions a passwordless account when `OAUTH_AUTO_REGISTER` is on.
- Gated by **`OAUTH_ENABLED`** (default `false` → `403`), so behavior is opt-in. New `OAUTH_*` settings + `.env.example`.

### Security
- Audience validation for Google blocks replayed tokens minted for other apps.
- Email-based linking only happens for **verified** provider emails.
- Failed verifications are audit-logged (`oauth_login_failed`).

### Tests
- `tests/test_oauth2.py` (12): endpoint gating, provider validation, verification failure, unverified-email rejection, auto-register, email-linking, repeat-login dedupe; provider-module unit tests with mocked HTTP (Google audience check, GitHub verified email).
- Updated 3 legacy `501` assertions → `403`.
- Full suite: **850 passed / 8 skipped**.