### PR TITLE
feat(ops): monitoring stack, alert rules, and scheduled backups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: ['--allow-multiple-documents']
       - id: check-added-large-files
         args: ['--maxkb=500']
       - id: check-merge-conflict

--- a/deploy/backup-cronjob.yaml
+++ b/deploy/backup-cronjob.yaml
@@ -1,0 +1,87 @@
+# Scheduled PostgreSQL backups for Plaidify on Kubernetes.
+#
+# Mirrors scripts/backup_db.sh (compressed pg_dump custom-format archives with
+# retention pruning) as an hourly CronJob writing to a PersistentVolume. Ship
+# the PV contents off-cluster (object storage) for real durability — see
+# docs/DISASTER_RECOVERY.md.
+#
+# Prerequisites:
+#   kubectl create secret generic plaidify-secrets \
+#     --from-literal=database-url='postgresql://user:pass@host:5432/plaidify'
+#
+# Apply:
+#   kubectl apply -f deploy/backup-cronjob.yaml
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: plaidify-backups
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: plaidify-db-backup
+spec:
+  schedule: "0 * * * *" # hourly, on the hour (UTC)
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  startingDeadlineSeconds: 600
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 1800
+      template:
+        spec:
+          restartPolicy: Never
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 70 # postgres user in the alpine image
+            fsGroup: 70
+          containers:
+            - name: backup
+              image: postgres:16-alpine
+              imagePullPolicy: IfNotPresent
+              env:
+                - name: DATABASE_URL
+                  valueFrom:
+                    secretKeyRef:
+                      name: plaidify-secrets
+                      key: database-url
+                - name: BACKUP_DIR
+                  value: /backups
+                - name: BACKUP_RETENTION
+                  value: "168" # keep ~7 days of hourly backups
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+                  FILE="${BACKUP_DIR}/plaidify-${STAMP}.dump"
+                  echo "Creating backup -> ${FILE}"
+                  pg_dump --format=custom --no-owner --no-privileges --file="${FILE}" "${DATABASE_URL}"
+                  echo "Backup complete ($(du -h "${FILE}" | cut -f1))."
+                  # Retention: keep newest ${BACKUP_RETENTION} archives.
+                  ls -1t "${BACKUP_DIR}"/plaidify-*.dump 2>/dev/null \
+                    | tail -n +$((BACKUP_RETENTION + 1)) \
+                    | xargs -r rm -f
+                  echo "Retention prune complete."
+              resources:
+                requests:
+                  cpu: "100m"
+                  memory: "128Mi"
+                limits:
+                  cpu: "500m"
+                  memory: "512Mi"
+              volumeMounts:
+                - name: backups
+                  mountPath: /backups
+          volumes:
+            - name: backups
+              persistentVolumeClaim:
+                claimName: plaidify-backups

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -1,0 +1,61 @@
+# Observability stack for Plaidify: Prometheus + Grafana, pre-provisioned with a
+# datasource, the overview dashboard, and alert rules.
+#
+# Prometheus scrapes the app's /metrics endpoint. The app runs in its own
+# compose project, so this stack attaches to that project's network. Set
+# PLAIDIFY_NETWORK to the app network name if it isn't the default
+# (`docker network ls` to find it, usually "<project>_default").
+#
+# Usage:
+#   docker compose -f docker-compose.production.yml up -d
+#   PLAIDIFY_NETWORK=plaidify_default docker compose -f docker-compose.monitoring.yml up -d
+#   # Grafana: http://localhost:3000  (admin / ${GRAFANA_ADMIN_PASSWORD:-admin})
+
+services:
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    restart: unless-stopped
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=15d"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./monitoring/alert_rules.yml:/etc/prometheus/alert_rules.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+    networks:
+      - default
+      - plaidify
+
+  grafana:
+    image: grafana/grafana:11.2.0
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+    volumes:
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - default
+
+volumes:
+  prometheus_data:
+  grafana_data:
+
+networks:
+  default:
+    name: plaidify-monitoring
+  # The app's network (from docker-compose.production.yml). Override the name
+  # with PLAIDIFY_NETWORK if your compose project name differs.
+  plaidify:
+    external: true
+    name: ${PLAIDIFY_NETWORK:-plaidify_default}

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,61 @@
+# Plaidify Observability & Ops Pack
+
+Deployable monitoring, alerting, and backup automation for a self-hosted
+Plaidify deployment. These are operator-facing configs — adjust targets,
+thresholds, and credentials for your environment.
+
+## Contents
+
+| File | Purpose |
+| ---- | ------- |
+| [prometheus.yml](prometheus.yml) | Prometheus scrape + rule config (scrapes `plaidify:8000/metrics`) |
+| [alert_rules.yml](alert_rules.yml) | Alerting rules (availability, error rate, latency, extraction failures, browser-pool saturation) |
+| [grafana/dashboards/plaidify-overview.json](grafana/dashboards/plaidify-overview.json) | Grafana dashboard (traffic, latency, errors, domain metrics) |
+| [grafana/provisioning/](grafana/provisioning/) | Auto-provisions the Prometheus datasource + dashboard |
+| [../docker-compose.monitoring.yml](../docker-compose.monitoring.yml) | Runs Prometheus + Grafana, pre-wired |
+| [../deploy/backup-cronjob.yaml](../deploy/backup-cronjob.yaml) | Kubernetes CronJob for scheduled DB backups |
+
+## Quick start (Docker Compose)
+
+```bash
+# 1. App stack (exposes /metrics on the plaidify service)
+docker compose -f docker-compose.production.yml up -d
+
+# 2. Monitoring stack — attach to the app network (find it with `docker network ls`)
+PLAIDIFY_NETWORK=plaidify_default GRAFANA_ADMIN_PASSWORD='choose-a-strong-one' \
+  docker compose -f docker-compose.monitoring.yml up -d
+```
+
+- Prometheus: <http://localhost:9090> (check **Status → Targets** shows `plaidify` UP)
+- Grafana: <http://localhost:3000> — the **Plaidify → Overview** dashboard is pre-loaded.
+
+## Metrics
+
+The app exposes (via `prometheus-fastapi-instrumentator` + `src/metrics.py`):
+
+- `http_request_duration_seconds{handler,method,status}` — request latency/throughput (auto-instrumented)
+- `plaidify_blueprint_extractions_total{site,status}` — extraction outcomes
+- `plaidify_browser_pool_active_contexts` — live browser-context gauge
+- `plaidify_mfa_challenges_total{mfa_type}` — MFA challenges encountered
+
+## Alerts
+
+Defined in [alert_rules.yml](alert_rules.yml). Tune `PlaidifyBrowserPoolSaturated`
+to your `BROWSER_POOL_SIZE`. To deliver alerts, run Alertmanager and uncomment
+the `alerting:` block in [prometheus.yml](prometheus.yml).
+
+| Alert | Severity | Fires when |
+| ----- | -------- | ---------- |
+| `PlaidifyInstanceDown` / `PlaidifyTargetMissing` | critical | target unreachable / absent |
+| `PlaidifyHighErrorRate` | critical | >5% 5xx over 5m |
+| `PlaidifyHighLatencyP95` | warning | p95 latency >2s over 10m |
+| `PlaidifyExtractionFailureRate` | warning | >20% extraction failures over 15m |
+| `PlaidifyBrowserPoolSaturated` | warning | active contexts at threshold for 10m |
+
+## Backups
+
+[../deploy/backup-cronjob.yaml](../deploy/backup-cronjob.yaml) runs hourly
+`pg_dump` archives to a PVC (mirrors [../scripts/backup_db.sh](../scripts/backup_db.sh)).
+For non-Kubernetes hosts, schedule the script via cron/systemd — see
+[../docs/DISASTER_RECOVERY.md](../docs/DISASTER_RECOVERY.md). Always replicate
+archives off-host to object storage.

--- a/monitoring/alert_rules.yml
+++ b/monitoring/alert_rules.yml
@@ -1,0 +1,76 @@
+groups:
+  - name: plaidify-availability
+    rules:
+      - alert: PlaidifyInstanceDown
+        expr: up{job="plaidify"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Plaidify instance is down ({{ $labels.instance }})"
+          description: "The Prometheus target for Plaidify has been unreachable for >2m."
+
+      - alert: PlaidifyTargetMissing
+        expr: absent(up{job="plaidify"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Plaidify scrape target is missing"
+          description: "No Plaidify target is being scraped. Check Prometheus service discovery / config."
+
+  - name: plaidify-traffic
+    rules:
+      - alert: PlaidifyHighErrorRate
+        # >5% of responses are 5xx over the last 5m.
+        expr: |
+          sum(rate(http_request_duration_seconds_count{job="plaidify",status=~"5.."}[5m]))
+            /
+          clamp_min(sum(rate(http_request_duration_seconds_count{job="plaidify"}[5m])), 0.001)
+            > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High 5xx error rate (>5%)"
+          description: "More than 5% of HTTP responses have been 5xx for >5m. Current value: {{ $value | humanizePercentage }}."
+
+      - alert: PlaidifyHighLatencyP95
+        # p95 request latency above 2s over 10m.
+        expr: |
+          histogram_quantile(
+            0.95,
+            sum(rate(http_request_duration_seconds_bucket{job="plaidify"}[5m])) by (le)
+          ) > 2
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "p95 latency above 2s"
+          description: "95th-percentile request latency has exceeded 2s for >10m (current: {{ $value | humanize }}s)."
+
+  - name: plaidify-domain
+    rules:
+      - alert: PlaidifyExtractionFailureRate
+        # >20% of blueprint extractions failing over 15m.
+        expr: |
+          sum(rate(plaidify_blueprint_extractions_total{status="error"}[15m]))
+            /
+          clamp_min(sum(rate(plaidify_blueprint_extractions_total[15m])), 0.001)
+            > 0.2
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Blueprint extraction failure rate >20%"
+          description: "More than 20% of extractions have failed for >15m. Check connectors, browser pool, and LLM provider health."
+
+      - alert: PlaidifyBrowserPoolSaturated
+        # Tune the threshold to your configured pool size (BROWSER_POOL_SIZE).
+        expr: plaidify_browser_pool_active_contexts >= 8
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Browser pool saturated"
+          description: "Active browser contexts have stayed at/above the alert threshold for >10m; requests may be queuing. Consider scaling executors or raising the pool size."

--- a/monitoring/grafana/dashboards/plaidify-overview.json
+++ b/monitoring/grafana/dashboards/plaidify-overview.json
@@ -1,0 +1,154 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "liveNow": false,
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["plaidify"],
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Plaidify — Overview",
+  "uid": "plaidify-overview",
+  "version": 1,
+  "templating": { "list": [] },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Instance Up",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" } } },
+            { "type": "value", "options": { "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "green", "value": 1 }] }
+        }
+      },
+      "options": { "colorMode": "background", "reduceOptions": { "calcs": ["lastNotNull"] } },
+      "targets": [
+        { "refId": "A", "datasource": { "type": "prometheus", "uid": "prometheus" }, "expr": "max(up{job=\"plaidify\"})" }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Request Rate (req/s) by Status",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 10, "x": 4, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "reqps", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (status) (rate(http_request_duration_seconds_count{job=\"plaidify\"}[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "5xx Error Rate (%)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 10, "x": 14, "y": 0 },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "custom": { "drawStyle": "line", "fillOpacity": 10 },
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }, { "color": "red", "value": 0.05 }] }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_request_duration_seconds_count{job=\"plaidify\",status=~\"5..\"}[5m])) / clamp_min(sum(rate(http_request_duration_seconds_count{job=\"plaidify\"}[5m])), 0.001)",
+          "legendFormat": "5xx ratio"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "timeseries",
+      "title": "Request Latency (p50 / p95 / p99)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s", "custom": { "drawStyle": "line", "fillOpacity": 5 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{job=\"plaidify\"}[5m])) by (le))",
+          "legendFormat": "p50"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"plaidify\"}[5m])) by (le))",
+          "legendFormat": "p95"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{job=\"plaidify\"}[5m])) by (le))",
+          "legendFormat": "p99"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Active Browser Contexts",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "short", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "plaidify_browser_pool_active_contexts",
+          "legendFormat": "active contexts"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Blueprint Extractions (rate by status)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (status) (rate(plaidify_blueprint_extractions_total[5m]))",
+          "legendFormat": "{{status}}"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "MFA Challenges (rate by type)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "ops", "custom": { "drawStyle": "line", "fillOpacity": 10 } } },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum by (mfa_type) (rate(plaidify_mfa_challenges_total[5m]))",
+          "legendFormat": "{{mfa_type}}"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/provider.yml
+++ b/monitoring/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: Plaidify
+    orgId: 1
+    folder: Plaidify
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    uid: prometheus
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,33 @@
+# Prometheus scrape + alerting config for Plaidify.
+#
+# Targets the app's built-in /metrics endpoint (enabled by
+# prometheus-fastapi-instrumentator). Service names assume the
+# docker-compose.monitoring.yml stack; adjust targets for your environment.
+
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  external_labels:
+    monitor: plaidify
+
+rule_files:
+  - /etc/prometheus/alert_rules.yml
+
+# Wire Alertmanager here when you run one (left commented so Prometheus starts
+# cleanly without it).
+# alerting:
+#   alertmanagers:
+#     - static_configs:
+#         - targets: ["alertmanager:9093"]
+
+scrape_configs:
+  - job_name: plaidify
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["plaidify:8000"]
+        labels:
+          service: plaidify
+
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
## Batch G — Operator enablement

Makes the 'operator wiring' readiness items press-go: monitoring, alerting, dashboards, and scheduled backups all ship as deployable configs.

### Monitoring & alerting
- **[monitoring/prometheus.yml](monitoring/prometheus.yml)** — scrapes `plaidify:8000/metrics`; Alertmanager block ready to uncomment.
- **[monitoring/alert_rules.yml](monitoring/alert_rules.yml)** — 5 rules: instance down / target missing (critical), >5% 5xx (critical), p95 latency >2s, >20% extraction failures, browser-pool saturation.
- **[monitoring/grafana/dashboards/plaidify-overview.json](monitoring/grafana/dashboards/plaidify-overview.json)** — 7-panel dashboard (traffic, error rate, latency percentiles, browser contexts, extraction + MFA rates), auto-provisioned with its datasource.

### One-command stack
- **[docker-compose.monitoring.yml](docker-compose.monitoring.yml)** — Prometheus + Grafana, pre-wired to the app network; Grafana loads the dashboard + datasource on boot.

### Scheduled backups
- **[deploy/backup-cronjob.yaml](deploy/backup-cronjob.yaml)** — hourly Kubernetes CronJob mirroring `scripts/backup_db.sh` (compressed `pg_dump` + retention) to a PVC.

### Notes
- All YAML/JSON validated (parse + structure).
- `pre-commit` `check-yaml` now allows multiple documents (k8s manifests are multi-doc).
- No application code changed — purely operator-facing configs.