### PR TITLE
feat(infra): HA parameters + high-availability & load-testing guides

### DIFF
--- a/docs/HIGH_AVAILABILITY.md
+++ b/docs/HIGH_AVAILABILITY.md
@@ -1,0 +1,98 @@
+# High Availability & Multi-Region
+
+How to run Plaidify with no single point of failure and how to extend it to a
+multi-region, active-passive topology. Pair this with
+[DISASTER_RECOVERY.md](DISASTER_RECOVERY.md) (backup/restore/failover) and
+[RELIABILITY_DESIGN.md](RELIABILITY_DESIGN.md) (in-app resilience).
+
+## Design principle: a stateless app tier
+
+The Plaidify API is stateless — all durable state lives in PostgreSQL, with
+Redis holding only ephemeral rate-limit/session data and the browser pool being
+per-instance and disposable. That means **HA is achieved by running ≥2 app
+replicas behind a load balancer plus HA backing services** — no app-side
+changes required.
+
+```mermaid
+flowchart TB
+  client[Clients / Agents] --> fd[Front Door / Traffic Manager]
+  fd --> r1[App replica 1]
+  fd --> r2[App replica 2]
+  r1 --> pg[(PostgreSQL Flexible Server<br/>Zone-redundant HA)]
+  r2 --> pg
+  r1 --> redis[(Redis<br/>Standard/Premium)]
+  r2 --> redis
+  r1 --> kv[(Key Vault / KMS)]
+  r2 --> kv
+```
+
+## Single-region HA (within one region)
+
+| Tier | Make it HA | How |
+| ---- | ---------- | --- |
+| **App (Container Apps)** | ≥2 replicas across zones | Set `minReplicas: 2+`. Zone redundancy requires a **VNet-injected** environment (`infrastructureSubnetId`) in a zone-enabled region — see below. |
+| **PostgreSQL** | Zone-redundant HA | Set `postgresSkuTier=GeneralPurpose` (HA isn't available on Burstable) and `postgresHighAvailabilityMode=ZoneRedundant` (now parameterized in `infra/main.bicep`). A hot standby in another zone fails over automatically. |
+| **Redis** | Replication / zones | Use `redisSkuName=Standard` (primary+replica, 99.9% SLA) or `Premium` for zone redundancy. |
+| **Backups** | Geo-redundant | Set `postgresGeoRedundantBackup=true` for cross-region restore capability. |
+
+### Enabling Postgres zone-redundant HA
+
+```bicep
+// main.bicepparam
+param postgresSkuTier = 'GeneralPurpose'
+param postgresSkuName = 'GP_Standard_D2ds_v5'
+param postgresHighAvailabilityMode = 'ZoneRedundant'
+param postgresStandbyAvailabilityZone = '2'
+param postgresGeoRedundantBackup = true
+```
+
+### Enabling Container Apps zone redundancy
+
+Zone redundancy for the managed environment requires VNet injection. Create the
+environment with an `infrastructureSubnetId` and `zoneRedundant: true`, then run
+the app with `minReplicas: 2+` so replicas spread across zones. This is a
+networking change beyond the default template — plan a VNet + delegated subnet
+(`/23` or larger) and set the subnet on the `Microsoft.App/managedEnvironments`
+resource.
+
+## Multi-region (active-passive)
+
+For regional-failure survival, run a warm standby in a second region:
+
+1. **Database** — enable geo-redundant backups (above) and/or create a
+   cross-region **read replica** that can be promoted. RPO depends on
+   replication lag (seconds) vs. geo-backup (up to the backup interval).
+2. **Secrets & keys** — replicate Key Vault secrets to the standby region and
+   use the **same** `ENCRYPTION_KEY` / KMS key (Azure Key Vault supports
+   multi-region access; AWS KMS supports multi-region keys). Without identical
+   key material the standby cannot decrypt credentials — see
+   [KMS_INTEGRATION.md](KMS_INTEGRATION.md).
+3. **Global entry point** — front both regions with **Azure Front Door** (or
+   Traffic Manager) using health-probe-based priority routing: primary first,
+   standby on failure.
+4. **Redis** — stand up a regional instance per region; it is not the source of
+   truth, so no cross-region replication is required.
+
+### Failover
+
+1. Confirm the primary is unhealthy (Front Door probes / `/health/detailed`).
+2. Promote the standby database (read replica) or restore from geo-backup
+   (see [DISASTER_RECOVERY.md](DISASTER_RECOVERY.md)).
+3. Point the standby app at the promoted DB; verify `/health/detailed` reports
+   `database`, `redis`, and `kms` all `ok`.
+4. Front Door shifts traffic automatically once the standby is healthy.
+
+### Targets
+
+| Topology | RPO | RTO |
+| -------- | --- | --- |
+| Single-region zone-redundant | ~0 (sync standby) | seconds–minutes (automatic) |
+| Multi-region, read replica | seconds (replication lag) | minutes (promote + cut over) |
+| Multi-region, geo-backup only | ≤ backup interval | ~1 hour (restore drill validated) |
+
+## Capacity & scaling
+
+Validate replica counts and autoscale rules against real load before relying on
+them — see [LOAD_TESTING.md](LOAD_TESTING.md). Scale the app tier on CPU/RPS and
+size the browser pool (`BROWSER_POOL_SIZE`) and access-executor replicas to the
+expected concurrent extraction volume.

--- a/docs/LOAD_TESTING.md
+++ b/docs/LOAD_TESTING.md
@@ -1,0 +1,67 @@
+# Load Testing & Capacity Planning
+
+Plaidify ships a [Locust](https://locust.io) harness so you can validate
+throughput, latency, and autoscale behaviour before going live and before
+trusting the HA replica counts in [HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md).
+
+## Running a test
+
+```bash
+pip install -r requirements-dev.txt   # includes locust
+./scripts/run-loadtest.sh --users 50 --rate 10 --time 60s --host http://localhost:8000
+```
+
+The scenario ([tests/load/locustfile.py](../tests/load/locustfile.py)) models a
+realistic mix per virtual user: registers + logs in on start, then weights
+`GET /health` (5), `GET /blueprints` (3), `GET /links` (2), `GET /auth/me` (1),
+and a mock connect (1). A `HealthOnlyUser` is available for pure probe load.
+
+For an interactive run with the web UI, drop `--headless`:
+
+```bash
+locust -f tests/load/locustfile.py --host http://localhost:8000
+# open http://localhost:8089
+```
+
+## Suggested SLOs
+
+Treat these as starting targets for the read-heavy API surface; tune to your
+hardware and traffic. The browser-driven extraction path is intentionally
+excluded — it is bound by the target sites and runs asynchronously.
+
+| Metric | Target |
+| ------ | ------ |
+| p50 latency (read endpoints) | < 100 ms |
+| p95 latency (read endpoints) | < 500 ms |
+| p99 latency (read endpoints) | < 1.5 s |
+| Error rate (5xx) | < 0.1% |
+| Throughput per app replica | establish a baseline, then scale linearly |
+
+These align with the Prometheus alert thresholds in
+[../monitoring/alert_rules.yml](../monitoring/alert_rules.yml)
+(`PlaidifyHighLatencyP95`, `PlaidifyHighErrorRate`).
+
+## Capacity-planning workflow
+
+1. **Baseline** — ramp one replica until p95 breaches the SLO; record the RPS at
+   that point as the per-replica ceiling.
+2. **Scale-out** — add replicas and confirm throughput scales roughly linearly
+   and latency holds (validates statelessness + no shared bottleneck).
+3. **Find the real bottleneck** — watch the Grafana dashboard
+   ([../monitoring/](../monitoring/)): if `plaidify_browser_pool_active_contexts`
+   saturates or DB CPU climbs first, scale executors / the database, not just
+   the app tier.
+4. **Set autoscale** — set Container Apps `minReplicas`/`maxReplicas` and the
+   scale rule (CPU or concurrent requests) with headroom above the measured
+   per-replica ceiling.
+5. **Re-test after changes** — load is a regression surface; re-run before major
+   releases.
+
+## CI smoke option
+
+For a fast guardrail, run a short low-concurrency profile against a disposable
+instance and assert the summary has zero failures:
+
+```bash
+USERS=10 RATE=5 TIME=30s ./scripts/run-loadtest.sh --host http://127.0.0.1:8000
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -133,4 +133,6 @@ python -m playwright install chromium
 - [ISOLATED_ACCESS_RUNTIME.md](ISOLATED_ACCESS_RUNTIME.md) for executor isolation design
 - [RUNBOOK.md](RUNBOOK.md) for operational procedures
 - [DISASTER_RECOVERY.md](DISASTER_RECOVERY.md) for backup, restore, and failover
+- [HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md) for HA and multi-region topology
+- [LOAD_TESTING.md](LOAD_TESTING.md) for load testing and capacity planning
 - [PRODUCT_PLAN.md](PRODUCT_PLAN.md) for roadmap context

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -78,6 +78,21 @@ param postgresSkuTier string = 'Burstable'
 
 param postgresVersion string = '16'
 param postgresStorageSizeGB int = 32
+
+@allowed([
+  'Disabled'
+  'SameZone'
+  'ZoneRedundant'
+])
+@description('PostgreSQL high-availability mode. ZoneRedundant/SameZone require the GeneralPurpose or MemoryOptimized tier (not Burstable).')
+param postgresHighAvailabilityMode string = 'Disabled'
+
+@description('Standby availability zone used when postgresHighAvailabilityMode is ZoneRedundant (must differ from the primary zone 1).')
+param postgresStandbyAvailabilityZone string = '2'
+
+@description('Enable geo-redundant PostgreSQL backups for cross-region disaster recovery.')
+param postgresGeoRedundantBackup bool = false
+
 param postgresDatabaseName string = 'plaidify'
 param logAnalyticsRetentionInDays int = 30
 
@@ -183,12 +198,17 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
     availabilityZone: '1'
     backup: {
       backupRetentionDays: 7
-      geoRedundantBackup: 'Disabled'
+      geoRedundantBackup: postgresGeoRedundantBackup ? 'Enabled' : 'Disabled'
     }
     createMode: 'Create'
-    highAvailability: {
-      mode: 'Disabled'
-    }
+    highAvailability: postgresHighAvailabilityMode == 'ZoneRedundant'
+      ? {
+          mode: 'ZoneRedundant'
+          standbyAvailabilityZone: postgresStandbyAvailabilityZone
+        }
+      : {
+          mode: postgresHighAvailabilityMode
+        }
     network: {
       publicNetworkAccess: 'Enabled'
     }

--- a/infra/main.json
+++ b/infra/main.json
@@ -5,7 +5,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.36.177.2456",
-      "templateHash": "10991426448070555761"
+      "templateHash": "1196368548119266529"
     }
   },
   "parameters": {
@@ -171,6 +171,32 @@
     "postgresStorageSizeGB": {
       "type": "int",
       "defaultValue": 32
+    },
+    "postgresHighAvailabilityMode": {
+      "type": "string",
+      "defaultValue": "Disabled",
+      "allowedValues": [
+        "Disabled",
+        "SameZone",
+        "ZoneRedundant"
+      ],
+      "metadata": {
+        "description": "PostgreSQL high-availability mode. ZoneRedundant/SameZone require the GeneralPurpose or MemoryOptimized tier (not Burstable)."
+      }
+    },
+    "postgresStandbyAvailabilityZone": {
+      "type": "string",
+      "defaultValue": "2",
+      "metadata": {
+        "description": "Standby availability zone used when postgresHighAvailabilityMode is ZoneRedundant (must differ from the primary zone 1)."
+      }
+    },
+    "postgresGeoRedundantBackup": {
+      "type": "bool",
+      "defaultValue": false,
+      "metadata": {
+        "description": "Enable geo-redundant PostgreSQL backups for cross-region disaster recovery."
+      }
     },
     "postgresDatabaseName": {
       "type": "string",
@@ -355,12 +381,10 @@
         "availabilityZone": "1",
         "backup": {
           "backupRetentionDays": 7,
-          "geoRedundantBackup": "Disabled"
+          "geoRedundantBackup": "[if(parameters('postgresGeoRedundantBackup'), 'Enabled', 'Disabled')]"
         },
         "createMode": "Create",
-        "highAvailability": {
-          "mode": "Disabled"
-        },
+        "highAvailability": "[if(equals(parameters('postgresHighAvailabilityMode'), 'ZoneRedundant'), createObject('mode', 'ZoneRedundant', 'standbyAvailabilityZone', parameters('postgresStandbyAvailabilityZone')), createObject('mode', parameters('postgresHighAvailabilityMode')))]",
         "network": {
           "publicNetworkAccess": "Enabled"
         },


### PR DESCRIPTION
## Batch I — Multi-region / HA readiness

Makes the 'multi-region HA + load validation' items press-go: the IaC can flip to HA, and the topology + capacity workflow are documented.

### Infrastructure (additive, safe defaults)
- **[infra/main.bicep](infra/main.bicep)** — new parameters, all defaulting to current behavior:
  - `postgresHighAvailabilityMode` (Disabled | SameZone | ZoneRedundant)
  - `postgresStandbyAvailabilityZone`
  - `postgresGeoRedundantBackup`
  - Wired into the flexible-server `highAvailability` + `backup` blocks.
- Regenerated **[infra/main.json](infra/main.json)**. Validated with `az bicep build` and `az bicep build-params`.
- An operator enables zone-redundant DB HA by setting the GeneralPurpose tier + `postgresHighAvailabilityMode=ZoneRedundant` — no template surgery.

### Docs
- **[docs/HIGH_AVAILABILITY.md](docs/HIGH_AVAILABILITY.md)** — stateless-tier HA design, per-tier guidance (app/Postgres/Redis/backups), multi-region active-passive topology (Front Door + read replica + replicated keys), failover steps, RPO/RTO targets.
- **[docs/LOAD_TESTING.md](docs/LOAD_TESTING.md)** — run the existing Locust harness, suggested SLOs (aligned to the Prometheus alert thresholds), and a capacity-planning workflow.
- Linked both from the docs index.

No application code changed; the test suite is unaffected.