### PR TITLE
docs(security): SOC 2 / ISO 27001 controls matrix + STRIDE threat model

### DIFF
--- a/docs/COMPLIANCE.md
+++ b/docs/COMPLIANCE.md
@@ -1,0 +1,78 @@
+# Compliance Readiness — Controls Matrix
+
+This document maps Plaidify's implemented controls to common audit frameworks
+(**SOC 2** Trust Service Criteria and **ISO/IEC 27001** Annex A) to accelerate a
+future audit. It is a readiness aid, **not** a certification or a statement of
+compliance — certification requires an independent auditor and organizational
+processes (see [Out of scope](#out-of-scope-organizational)).
+
+Status legend:
+- ✅ **Implemented** — enforced in code/infra in this repo (evidence linked).
+- ⚙️ **Operator** — supported, but the deploying organization must configure/run it.
+- 🏢 **Organizational** — a process/legal/personnel control outside the codebase.
+
+Cross-reference: [SECURITY.md](../SECURITY.md) (architecture),
+[KMS_INTEGRATION.md](KMS_INTEGRATION.md), [DISASTER_RECOVERY.md](DISASTER_RECOVERY.md),
+[HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md), [THREAT_MODEL.md](THREAT_MODEL.md).
+
+## Security (SOC 2 Common Criteria / ISO 27001)
+
+| Control area | SOC 2 | ISO 27001 (A.) | Status | Implementation & evidence |
+| ------------ | ----- | -------------- | ------ | ------------------------- |
+| Logical access — authentication | CC6.1 | A.5.15, A.8.5 | ✅ | JWT (short-lived access + rotating refresh), API keys (SHA-256 hashed), OAuth2 (Google/GitHub, verified-email required) — `src/routers/auth.py`, `src/oauth_providers.py` |
+| Authorization / least privilege | CC6.3 | A.5.15, A.8.2 | ✅ | Role-based admin (`is_admin`), scoped API keys & agents, consent scopes — `src/routers/admin.py`, `src/dependencies.py` |
+| Brute-force / credential protection | CC6.1 | A.8.5 | ✅ | bcrypt password hashing, account lockout (5 fails → 15 min), MFA-challenge metering, rate limiting — `src/routers/auth.py`, `src/dependencies.py` |
+| Encryption at rest | CC6.1 | A.8.24 | ✅ | Envelope encryption (per-user DEK) + pluggable KMS (Local/AWS/Azure/Vault) — `src/database.py`, `src/kms.py` |
+| Encryption in transit | CC6.7 | A.8.24 | ⚙️ | HSTS + HTTPS enforcement when `ENFORCE_HTTPS=true`; terminate TLS at the proxy — `src/app.py`, `nginx/` |
+| Key management & rotation | CC6.1 | A.8.24 | ✅/⚙️ | Master-key rotation + background re-encryption; HSM-backed wrapping via managed KMS — `src/kms.py`, `docs/KMS_INTEGRATION.md` |
+| Secrets management | CC6.1 | A.8.24 | ✅/⚙️ | No secrets in source (gitleaks in CI), Key Vault references in IaC, `.env.example` guidance — `.pre-commit-config.yaml`, `infra/main.bicep` |
+| Network / edge hardening | CC6.6 | A.8.20, A.8.23 | ✅ | Security headers (CSP, X-Frame-Options, X-Content-Type-Options, HSTS), CORS production guard, request-size limits — `src/app.py` |
+| Audit logging & integrity | CC7.2 | A.8.15 | ✅ | Tamper-evident hash-chained audit log + verification endpoint — `src/audit.py`, `src/database.py` |
+| Change management / SDLC | CC8.1 | A.8.25, A.8.28 | ✅ | CI: lint, multi-version tests, CodeQL, secret scan, `pip-audit`, Docker build; pre-commit hooks — `.github/workflows/ci.yml` |
+| Vulnerability management | CC7.1 | A.8.8 | ✅/⚙️ | `pip-audit` (strict) + CodeQL in CI; Dependabot updates; operators patch on cadence — `.github/workflows/ci.yml` |
+| Monitoring & alerting | CC7.2 | A.8.15, A.8.16 | ⚙️ | Prometheus metrics + alert rules + Grafana dashboard; OpenTelemetry traces; Sentry — `monitoring/`, `src/tracing.py` |
+| Incident response | CC7.3–7.5 | A.5.24–5.28 | 🏢/⚙️ | Runbooks + DR procedures provided; org must define on-call, severities, comms — `docs/RUNBOOK.md`, `docs/DISASTER_RECOVERY.md` |
+
+## Availability (SOC 2 A-series)
+
+| Control | SOC 2 | ISO 27001 | Status | Evidence |
+| ------- | ----- | --------- | ------ | -------- |
+| Resilience / fault tolerance | A1.1 | A.8.6 | ✅ | Circuit breakers, retry-with-backoff, rate-limit fail-open, bounded health probes — `src/core/circuit_breaker.py`, `src/routers/system.py` |
+| Capacity planning | A1.1 | A.8.6 | ⚙️ | Load-test harness + SLOs + workflow — `docs/LOAD_TESTING.md`, `scripts/run-loadtest.sh` |
+| High availability | A1.2 | A.8.14 | ⚙️ | Stateless tier + zone-redundant DB params + multi-region topology — `docs/HIGH_AVAILABILITY.md`, `infra/main.bicep` |
+| Backup & recovery | A1.2 | A.8.13 | ✅/⚙️ | Backup script + hourly CronJob + DR runbook with restore drill — `scripts/backup_db.sh`, `deploy/backup-cronjob.yaml`, `docs/DISASTER_RECOVERY.md` |
+
+## Confidentiality & Privacy (SOC 2 C / P-series, GDPR)
+
+| Control | SOC 2 | ISO 27001 | Status | Evidence |
+| ------- | ----- | --------- | ------ | -------- |
+| Data classification & handling | C1.1 | A.5.12 | ✅ | Credentials encrypted per-user; PII kept out of logs — `src/database.py`, `src/logging_config.py` |
+| Consent management | P3.1 | A.5.34 | ✅ | Agent consent requests/grants with scopes + expiry — `src/routers/consent.py` |
+| Right to erasure (GDPR Art. 17) | P4.2 | A.5.34 | ✅ | `DELETE /auth/me` erases all user data; audit trail preserved — `src/routers/auth.py`, `src/database.py` |
+| Data retention | C1.2 | A.5.33 | ✅/⚙️ | Configurable audit retention + cleanup jobs — `src/app.py`, `AUDIT_RETENTION_DAYS` |
+| Processing integrity | PI1.1 | A.8.24 | ✅ | Tamper-evident audit chain; scoped, consented data access — `src/audit.py`, `src/routers/consent.py` |
+
+## Pre-audit / pre-pentest checklist
+
+Before engaging an auditor or penetration tester:
+
+- [ ] Deploy with `ENV=production`, `DEBUG=false`, `ENFORCE_HTTPS=true`, non-wildcard `CORS_ORIGINS`.
+- [ ] `REGISTRATION_ENABLED=false`; provision accounts via bootstrap; confirm an admin exists.
+- [ ] Managed KMS configured (`KMS_PROVIDER` ≠ `local`) with the key in an HSM-backed vault.
+- [ ] Secrets sourced from a vault (no plaintext env in source/CI); rotate any shared dev secrets.
+- [ ] `/health/detailed` gated by `HEALTH_CHECK_TOKEN`; metrics/Grafana not publicly exposed.
+- [ ] Backups scheduled + a restore drill completed and timed against the RTO.
+- [ ] Alerting wired to a real channel (Alertmanager); on-call defined.
+- [ ] Latest dependencies; CI green (CodeQL, `pip-audit`, secret scan) on `main`.
+- [ ] Review [THREAT_MODEL.md](THREAT_MODEL.md) mitigations and confirm scope with the tester.
+
+## Out of scope (organizational)
+
+These cannot be satisfied by code and must be handled by the operating organization:
+
+- Independent SOC 2 Type II / ISO 27001 audit and certification.
+- Personnel controls: background checks, security training, access reviews, onboarding/offboarding.
+- Vendor/sub-processor risk management and Data Processing Agreements (DPAs).
+- Formal, signed policies (information security, acceptable use, incident response, BCP/DR).
+- Physical security (inherited from the cloud provider — collect their attestations).
+- Legal: privacy notice, records of processing (GDPR Art. 30), breach-notification procedures.

--- a/docs/README.md
+++ b/docs/README.md
@@ -135,4 +135,6 @@ python -m playwright install chromium
 - [DISASTER_RECOVERY.md](DISASTER_RECOVERY.md) for backup, restore, and failover
 - [HIGH_AVAILABILITY.md](HIGH_AVAILABILITY.md) for HA and multi-region topology
 - [LOAD_TESTING.md](LOAD_TESTING.md) for load testing and capacity planning
+- [COMPLIANCE.md](COMPLIANCE.md) for the SOC 2 / ISO 27001 controls matrix
+- [THREAT_MODEL.md](THREAT_MODEL.md) for the STRIDE threat model
 - [PRODUCT_PLAN.md](PRODUCT_PLAN.md) for roadmap context

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,75 @@
+# Threat Model
+
+A STRIDE-based threat model for Plaidify. It complements
+[SECURITY.md](../SECURITY.md) (architecture) and [COMPLIANCE.md](COMPLIANCE.md)
+(controls matrix), and is intended to scope security reviews and penetration
+tests.
+
+## Scope & assets
+
+Plaidify brokers authenticated access to third-party sites on a user's behalf.
+The crown-jewel assets are:
+
+1. **Stored site credentials** — encrypted username/password per user (envelope-encrypted).
+2. **Master / KMS key material** — unwraps the per-user DEKs.
+3. **Auth tokens** — JWTs, refresh tokens, API keys, consent grants.
+4. **The audit log** — tamper-evident record of access.
+
+## Trust boundaries
+
+```mermaid
+flowchart LR
+  subgraph Untrusted
+    dev[API developer]
+    user[Hosted-Link end user]
+    agent[MCP / AI agent]
+  end
+  subgraph Plaidify [Plaidify trust boundary]
+    api[FastAPI app]
+    exec[Browser executor<br/>isolated runtime]
+  end
+  subgraph Data [Encrypted state]
+    db[(PostgreSQL<br/>encrypted creds)]
+    redis[(Redis)]
+    kms[(KMS / Key Vault)]
+  end
+  ext[Third-party sites]
+  llm[LLM provider]
+
+  dev & user & agent -->|TLS + authn| api
+  api --> db
+  api --> redis
+  api --> kms
+  api --> exec
+  exec -->|user creds| ext
+  api -->|DOM, no secrets| llm
+```
+
+## STRIDE analysis
+
+| # | Category | Threat | Mitigations (implemented) | Residual risk / operator action |
+| - | -------- | ------ | ------------------------- | ------------------------------- |
+| 1 | **Spoofing** | Forged identity / stolen token | Signed JWTs, rotating refresh tokens, hashed API keys, OAuth2 with verified email + Google audience check, account lockout | Use short token TTLs; consider end-user MFA; protect the signing key |
+| 2 | **Spoofing** | OAuth token substitution (confused deputy) | Google `tokeninfo` audience check vs `OAUTH_GOOGLE_CLIENT_ID`; GitHub tokens are app-scoped | Set the client id; restrict providers via `OAUTH_ALLOWED_PROVIDERS` |
+| 3 | **Tampering** | Modify data in transit | TLS/HSTS, strict CORS, request-size limits, security headers | Terminate TLS correctly; pin `CORS_ORIGINS` |
+| 4 | **Tampering** | Alter audit history | SHA-256 hash-chained audit log + `/audit/verify` | Periodically verify the chain; ship logs to WORM storage |
+| 5 | **Repudiation** | Deny performing an action | Per-action audit entries (user/agent, IP, scope, timestamp) | Retain logs per policy; centralize off-host |
+| 6 | **Info disclosure** | Theft of stored credentials | Envelope encryption (per-user DEK), KMS-wrapped master key, no plaintext at rest | Use managed KMS (HSM); least-privilege DB access |
+| 7 | **Info disclosure** | Secrets in logs / errors | PII-safe structured logging; `DEBUG=false` in prod (enforced) | Review custom log statements; scrub sink integrations |
+| 8 | **Info disclosure** | Credentials leak to the LLM | Only simplified DOM (no secrets) is sent to the model; browser guardrails | Review connector prompts; prefer self-hosted models for sensitive sites |
+| 9 | **Info disclosure** | Health/metrics expose internals | `/health/detailed` token-gated; `/metrics` not public by default | Keep metrics/Grafana behind auth/VPN |
+| 10 | **DoS** | Request flooding / abusive load | Rate limiting (Redis-backed, fail-open), request-size cap, circuit breakers, autoscale | Add edge WAF/DDoS protection; tune limits |
+| 11 | **DoS** | Stuck backend hangs requests | Bounded health probes, browser-pool circuit breaker, timeouts, graceful shutdown | Size the browser pool; alert on saturation |
+| 12 | **Elevation of privilege** | Normal user gains admin | RBAC (`is_admin`), admins can't self-deactivate, scoped keys/agents | Review admin grants; audit `promote` events |
+| 13 | **Elevation of privilege** | Agent exceeds granted scope | Consent scopes + expiry, per-agent allowed sites/scopes, isolated executor | Grant minimal scopes; expire grants promptly |
+| 14 | **Elevation of privilege** | Malicious target-site content (SSRF/RCE via browser) | Isolated access runtime, read-only browser guardrails, no secret exfil to LLM | Run executors network-segmented; keep Chromium patched |
+
+## Residual risks & assumptions
+
+- **Key custody:** with `KMS_PROVIDER=local`, the master key is an env secret — its compromise exposes all credentials. Use managed HSM-backed KMS in production.
+- **Compromised dependencies:** mitigated by `pip-audit`/CodeQL/Dependabot, but a zero-day in a transitive dep is a residual risk — patch promptly.
+- **Insider access to the database host:** data is encrypted at rest, but a host with both DB and master-key access can decrypt. Separate the KMS blast radius (see [KMS_INTEGRATION.md](KMS_INTEGRATION.md)).
+- **Target-site abuse:** Plaidify acts with user-delegated credentials; per-site allow-lists and consent scopes limit blast radius.
+
+Re-run this analysis when adding a trust boundary (new external integration, new
+client surface, or a change to where credentials/keys flow).


### PR DESCRIPTION
## Batch J — Compliance & security-review readiness

Makes the 'security audit / SOC 2 / ISO 27001' items press-go by mapping what's already built to audit frameworks and documenting the threat model a pentester will ask for.

### Added
- **[docs/COMPLIANCE.md](docs/COMPLIANCE.md)** — controls matrix mapping implemented features to **SOC 2** Trust Service Criteria and **ISO 27001 Annex A** (Security, Availability, Confidentiality, Privacy), each row linked to its evidence in the repo. Includes a **pre-audit / pre-pentest checklist** and an explicit **out-of-scope (organizational)** list so expectations are honest — certification still needs an auditor and org processes.
- **[docs/THREAT_MODEL.md](docs/THREAT_MODEL.md)** — **STRIDE** analysis with a trust-boundary diagram, 14 threats mapped to implemented mitigations, and residual risks (key custody, dependencies, insider access, target-site abuse).

### Notes
- Docs-only; cross-references [SECURITY.md](SECURITY.md) and the features shipped in batches A–I.
- Status legend distinguishes ✅ implemented / ⚙️ operator-configured / 🏢 organizational, so it's a readiness aid, not a compliance claim.