### PR TITLE
docs(readme): revamp GitHub presentation

### DIFF
--- a/.github/assets/banner.svg
+++ b/.github/assets/banner.svg
@@ -1,0 +1,51 @@
+<svg width="1280" height="320" viewBox="0 0 1280 320" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Plaidify - the open-source gateway to authenticated web data">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1280" y2="320" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0A0E1F"/>
+      <stop offset="0.5" stop-color="#121A3A"/>
+      <stop offset="1" stop-color="#0A0E1F"/>
+    </linearGradient>
+    <linearGradient id="accent" x1="980" y1="80" x2="1200" y2="240" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#6E9BFF"/>
+      <stop offset="1" stop-color="#3CE0CD"/>
+    </linearGradient>
+    <radialGradient id="glow" cx="0.82" cy="0.42" r="0.5">
+      <stop offset="0" stop-color="#3E5BC0" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#3E5BC0" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+
+  <rect width="1280" height="320" rx="16" fill="url(#bg)"/>
+  <rect width="1280" height="320" rx="16" fill="url(#glow)"/>
+
+  <!-- node graph motif: a client fanning out to authorized sites -->
+  <g stroke="url(#accent)" stroke-width="3" opacity="0.95">
+    <line x1="1000" y1="160" x2="1092" y2="86"/>
+    <line x1="1000" y1="160" x2="1116" y2="160"/>
+    <line x1="1000" y1="160" x2="1092" y2="234"/>
+    <line x1="1092" y1="86" x2="1188" y2="112"/>
+    <line x1="1092" y1="234" x2="1188" y2="208"/>
+  </g>
+  <g fill="#1B2547" stroke="url(#accent)" stroke-width="3.5">
+    <circle cx="1092" cy="86" r="16"/>
+    <circle cx="1116" cy="160" r="16"/>
+    <circle cx="1092" cy="234" r="16"/>
+    <circle cx="1188" cy="112" r="11"/>
+    <circle cx="1188" cy="208" r="11"/>
+  </g>
+  <circle cx="1000" cy="160" r="26" fill="#1B2547" stroke="url(#accent)" stroke-width="4"/>
+  <circle cx="1000" cy="160" r="11" fill="#3CE0CD"/>
+
+  <!-- wordmark -->
+  <text x="84" y="190" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="104" font-weight="800" fill="#FFFFFF" letter-spacing="-3">Plaidify<tspan fill="#6E9BFF">.</tspan></text>
+
+  <!-- surface pills -->
+  <g font-family="SFMono-Regular, Consolas, Menlo, monospace" font-size="18" font-weight="600">
+    <rect x="88" y="232" width="132" height="40" rx="20" fill="#1B2547" stroke="#33407A"/>
+    <text x="154" y="258" fill="#B7C4EC" text-anchor="middle">REST API</text>
+    <rect x="232" y="232" width="166" height="40" rx="20" fill="#1B2547" stroke="#33407A"/>
+    <text x="315" y="258" fill="#B7C4EC" text-anchor="middle">Hosted Link</text>
+    <rect x="410" y="232" width="158" height="40" rx="20" fill="#1B2547" stroke="#33407A"/>
+    <text x="489" y="258" fill="#B7C4EC" text-anchor="middle">MCP Agents</text>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,121 +1,182 @@
-# Plaidify
+<div align="center">
 
-Plaidify is a production-oriented authenticated web access service. It gives you API, hosted-link, and agent-facing interfaces for connecting to user-authorized sites, navigating MFA, and returning structured results under a strict read-only posture.
+<img src=".github/assets/banner.svg" alt="Plaidify" width="100%">
 
-## What Plaidify Provides
+<h3>The open-source gateway to authenticated web data.</h3>
+
+<p>Connect to any user-authorized website, clear MFA, and return structured data —<br>through a REST API, a Plaid-style hosted link, or an MCP server for AI agents.</p>
+
+<p>
+  <a href="https://github.com/meetpandya27/plaidify/actions/workflows/ci.yml"><img src="https://github.com/meetpandya27/plaidify/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <img src="https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/FastAPI-009688?logo=fastapi&logoColor=white" alt="FastAPI">
+  <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Ruff"></a>
+  <a href="CONTRIBUTING.md"><img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg" alt="PRs welcome"></a>
+</p>
+
+<p>
+  <a href="#quick-start"><b>Quick Start</b></a> ·
+  <a href="docs/README.md"><b>Documentation</b></a> ·
+  <a href="#sdks"><b>SDKs</b></a> ·
+  <a href="#architecture"><b>Architecture</b></a> ·
+  <a href="#production-readiness"><b>Production</b></a> ·
+  <a href="CONTRIBUTING.md"><b>Contributing</b></a>
+</p>
+
+</div>
+
+---
+
+## Overview
+
+Plaid connects apps to **banks** through official APIs. Plaidify connects apps to **any website** through a secure, headless browser runtime — logging in with user-authorized credentials, handling MFA, and returning typed, structured data under a strict **read-only** posture.
+
+Use it three ways, from the same engine:
 
 | Surface | Use it when | Primary endpoints |
 | --- | --- | --- |
-| Direct API | Your backend owns the connect flow and polling lifecycle | `POST /connect`, `POST /mfa/submit`, `GET /access_jobs` |
-| Hosted Link | You need a Plaid-style launch flow in web or mobile clients | `POST /link/sessions`, `POST /link/bootstrap`, `POST /link/sessions/bootstrap` |
-| Agent and MCP access | An internal tool or AI agent needs constrained access to a site workflow | `GET /blueprints`, agent-facing routes, MCP server |
+| **Direct API** | Your backend owns the connect flow and polling lifecycle | `POST /connect`, `POST /mfa/submit`, `GET /access_jobs` |
+| **Hosted Link** | You want a Plaid-style launch flow in web or mobile clients | `POST /link/sessions`, `POST /link/bootstrap`, `POST /link/sessions/bootstrap` |
+| **Agents & MCP** | An internal tool or AI agent needs constrained access to a workflow | `GET /blueprints`, agent routes, built-in MCP server |
 
-## Core Capabilities
+> [!NOTE]
+> Plaidify never writes to target sites. Every flow runs through read-only browser guardrails, scoped access tokens, consent grants, and a tamper-evident audit log.
 
-- Hosted link flows for browser, iframe, and native mobile webview clients
-- Signed bootstrap tokens for production-safe hosted-link launches
-- Detached access jobs with polling, persisted results, and MFA continuation
-- Scoped access control, audit-aware workflows, and read-only execution
-- Credential encryption in transit and at rest
-- Python, TypeScript, and Swift SDK surfaces for server, web, and native integrations
+## Architecture
 
-## How It Works
-
-1. Create a hosted-link session or call `POST /connect` directly.
-2. Plaidify executes the connector or blueprint flow and captures any MFA state.
-3. Clients continue MFA through the hosted link or `POST /mfa/submit`.
-4. Hosted clients receive a short-lived `public_token`, while durable results are retrieved later through server-side exchange or `GET /access_jobs`.
-
-## Architecture At A Glance
-
-```text
-Client or agent
-	-> Plaidify API or hosted /link flow
-	-> access-job orchestration and MFA state
-	-> connector runtime or blueprint execution
-	-> structured result payload
+```mermaid
+flowchart LR
+  subgraph Clients
+    A[Backend / Direct API]
+    B[Web & Mobile<br/>Hosted Link]
+    C[AI Agents<br/>MCP server]
+  end
+  A --> API
+  B --> API
+  C --> API
+  API[Plaidify API<br/>FastAPI] --> JOBS[Access-job orchestration<br/>+ MFA state]
+  JOBS --> ENGINE[Connector / Blueprint engine]
+  ENGINE --> BROWSER[Headless browser<br/>read-only]
+  BROWSER --> SITE[(User-authorized site)]
+  ENGINE --> OUT[Structured result]
+  API -.-> PG[(PostgreSQL<br/>encrypted creds)]
+  API -.-> REDIS[(Redis)]
+  API -.-> KMS[(KMS / Key Vault)]
 ```
 
-Operationally, Plaidify is a FastAPI service with modular routers, Redis-backed shared state for multi-worker coordination, a detached access-job execution path for production deployments, and hosted-link assets that can be embedded in parent apps or native webviews.
+Plaidify is a FastAPI service with modular routers, Redis-backed shared state for multi-worker coordination, a detached access-job execution path for restart-tolerant production runs, and hosted-link assets that embed in parent apps or native webviews.
 
 ## Quick Start
 
-### Try the full flow in one command
+### Try the whole flow in one command
 
-Run a complete, self-contained journey — register, connect, MFA, and structured
-extraction — against a bundled demo portal. No external site, API keys, or setup
-required:
+Run a complete, self-contained journey — register, connect, MFA, and structured extraction — against a bundled demo site. No external site, API keys, or setup required:
 
 ```bash
 python scripts/demo.py
 ```
 
-This spins up a demo target site plus the Plaidify API, then drives the whole
-stack (auth → connector execution → headless browser → MFA → typed data). Use
-`--no-mfa` for the no-MFA path, or `--base-url https://your-plaidify` to smoke-test
-an existing deployment (set `DEMO_MODE=true` on that server). The bundled
-`demo_utility` connector is only discoverable when `DEMO_MODE=true`, so it never
-leaks into production discovery.
+This spins up a demo target site plus the Plaidify API, then drives the full stack (auth → connector execution → headless browser → MFA → typed data). Use `--no-mfa` for the no-MFA path, or `--base-url https://your-plaidify` to smoke-test an existing deployment (set `DEMO_MODE=true` there). The bundled `demo_utility` connector is only discoverable when `DEMO_MODE=true`, so it never leaks into production discovery.
 
 ### Docker Compose
 
 ```bash
 cp .env.example .env
 # Set ENCRYPTION_KEY and JWT_SECRET_KEY before starting
-
 docker compose up --build
 curl http://localhost:8000/health
 ```
 
-### Local Development
+### Local development
 
 ```bash
 cp .env.example .env
 # Set ENCRYPTION_KEY and JWT_SECRET_KEY before starting
-
 alembic upgrade head
 uvicorn src.main:app --reload
 ```
 
-## Production Notes
-
-- Use PostgreSQL and Redis in production.
-- Prefer `POST /link/bootstrap` plus `POST /link/sessions/bootstrap` for hosted client launches.
-- Keep `CORS_ORIGINS` explicit and enable HTTPS enforcement.
-- Run detached access jobs with the Redis-worker execution mode for restart-tolerant production behavior.
-- Treat fixture connectors as local test assets, not public production integrations.
+Interactive API docs are served at `http://localhost:8000/docs`.
 
 ## SDKs
 
-- [sdk/README.md](sdk/README.md) for the Python SDK
-- [sdk-js/README.md](sdk-js/README.md) for the TypeScript and browser SDK
-- `sdk-swift/` for the native iOS hosted-link package
+First-party clients for server, web, and native targets:
 
-## Key Docs
+| SDK | Language | Path |
+| --- | --- | --- |
+| Server | Python | [sdk/](sdk/README.md) |
+| Web & Node | TypeScript / JavaScript | [sdk-js/](sdk-js/README.md) |
+| iOS | Swift | [sdk-swift/](sdk-swift/) |
+| Android | Kotlin | [sdk-android/](sdk-android/README.md) |
 
-- [docs/SELF_HOST.md](docs/SELF_HOST.md) — fork-to-deployed Azure walkthrough for self-hosters
-- [docs/README.md](docs/README.md) for the technical architecture and configuration reference
-- [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) for production deployment and operations guidance
-- [docs/MOBILE_LINK_INTEGRATION.md](docs/MOBILE_LINK_INTEGRATION.md) for native mobile hosted-link integration
-- [docs/AGENTS.md](docs/AGENTS.md) for agent-facing usage
-- [docs/RUNBOOK.md](docs/RUNBOOK.md) for operational procedures
-- [docs/PRODUCT_PLAN.md](docs/PRODUCT_PLAN.md) for roadmap context
+## Production readiness
 
-## Validation
+Plaidify is built to run in production, not just to demo. The hardening is in the repo and exercised in CI:
+
+| Area | What's built in | Reference |
+| --- | --- | --- |
+| **Security** | Envelope encryption with pluggable KMS (Local / AWS / Azure / Vault), OAuth2 social login, RBAC, scoped API keys, tamper-evident audit hash chain, security headers | [SECURITY.md](SECURITY.md) · [THREAT_MODEL.md](docs/THREAT_MODEL.md) |
+| **Resilience** | Circuit breakers, retry-with-backoff, rate-limit fail-open, bounded health probes, graceful shutdown | [HIGH_AVAILABILITY.md](docs/HIGH_AVAILABILITY.md) |
+| **Observability** | Prometheus metrics + alert rules, provisioned Grafana dashboard, OpenTelemetry tracing, Sentry | [monitoring/](monitoring/README.md) |
+| **Data & DR** | GDPR account erasure, scheduled backups, documented restore/failover drills | [DISASTER_RECOVERY.md](docs/DISASTER_RECOVERY.md) |
+| **Compliance** | SOC 2 / ISO 27001 controls matrix + pre-audit checklist | [COMPLIANCE.md](docs/COMPLIANCE.md) |
+
+CI runs lint, a 3.10–3.12 test matrix (800+ tests), a hosted-link Playwright E2E slice, `pip-audit`, CodeQL, secret scanning, and a Docker build on every change.
+
+## Features
+
+- **Read-only by design** — browser guardrails, scoped tokens, consent grants, and an immutable audit trail.
+- **MFA handling** — detached access jobs capture and continue MFA via the hosted link or `POST /mfa/submit`.
+- **Encryption everywhere** — credentials are envelope-encrypted at rest with per-user keys; TLS/HSTS in transit.
+- **Hosted Link** — launch flows for browser, iframe, and native mobile webview clients, with signed bootstrap tokens.
+- **Agent-native** — a built-in MCP server and blueprint discovery for constrained AI-agent access.
+- **Restart-tolerant** — Redis-worker execution mode keeps detached jobs durable across restarts.
+
+## Documentation
+
+| Guide | Description |
+| --- | --- |
+| [docs/README.md](docs/README.md) | Architecture & configuration reference |
+| [docs/SELF_HOST.md](docs/SELF_HOST.md) | Fork-to-deployed Azure walkthrough |
+| [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md) | Production deployment & operations |
+| [docs/MOBILE_LINK_INTEGRATION.md](docs/MOBILE_LINK_INTEGRATION.md) | Native mobile hosted-link integration |
+| [docs/AGENTS.md](docs/AGENTS.md) | Agent-facing usage and the MCP server |
+| [docs/HIGH_AVAILABILITY.md](docs/HIGH_AVAILABILITY.md) | HA & multi-region topology |
+| [docs/DISASTER_RECOVERY.md](docs/DISASTER_RECOVERY.md) | Backup, restore, and failover |
+| [docs/RUNBOOK.md](docs/RUNBOOK.md) | Day-2 operational procedures |
+
+## Production notes
+
+- Use PostgreSQL and Redis in production.
+- Prefer `POST /link/bootstrap` + `POST /link/sessions/bootstrap` for hosted client launches.
+- Keep `CORS_ORIGINS` explicit and enable HTTPS enforcement.
+- Run detached access jobs in Redis-worker mode for restart-tolerant behavior.
+- Treat fixture connectors as local test assets, not public production integrations.
+
+## Testing
 
 ```bash
+# Full suite
+PYTHONPATH=$PWD python -m pytest tests/ -q
+
+# Targeted slices
 python -m pytest tests/test_agent_integration.py -q
 PYTHONPATH=$PWD python -m pytest tests/test_hosted_link_e2e.py -q -m playwright
 cd sdk-js && npm run typecheck && npm test
 cd sdk-swift && swift test
 ```
 
-Install the browser once before running the hosted-link E2E slice:
+Install the browser once before the hosted-link E2E slice:
 
 ```bash
 python -m playwright install chromium
 ```
 
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md). Found a security issue? Please follow [SECURITY.md](SECURITY.md) for responsible disclosure.
+
 ## License
 
-MIT. See [LICENSE](LICENSE).
+[MIT](LICENSE) © Plaidify contributors.


### PR DESCRIPTION
## README & presentation revamp

A complete refresh of how Plaidify presents on GitHub.

### What changed
- **Hero banner** — a new self-contained SVG ([.github/assets/banner.svg](.github/assets/banner.svg)) with the wordmark, surface pills (REST API / Hosted Link / MCP Agents), and a node-graph motif. Renders in both light and dark GitHub themes.
- **Centered hero** — tagline, status badges (CI, license, Python, FastAPI, Ruff, PRs welcome), and section navigation.
- **Architecture** — replaced the ASCII sketch with a Mermaid diagram of the client → API → engine → browser → result flow.
- **Production-readiness matrix** — surfaces the security/resilience/observability/DR/compliance work with links to the supporting docs.
- **All four SDKs** — Python, TypeScript, Swift, and Kotlin (the Android SDK was previously omitted).
- **Documentation index** + clearer quick-start (one-command demo, Docker, local).

### Verification
- All internal links checked to resolve to existing files.
- Banner SVG validated as well-formed XML and visually confirmed to render.
- No application code touched.